### PR TITLE
refactor: #46 AuditInformation 클래스 칼럼명 소문자로 변경

### DIFF
--- a/src/main/java/com/moyorak/infra/orm/AuditInformation.java
+++ b/src/main/java/com/moyorak/infra/orm/AuditInformation.java
@@ -17,7 +17,7 @@ public abstract class AuditInformation {
 
     @CreatedDate
     @Comment("생성 일자")
-    @Column(name = "CREATED_DATE", nullable = false, updatable = false)
+    @Column(name = "created_date", nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
     //    @CreatedBy
@@ -27,7 +27,7 @@ public abstract class AuditInformation {
 
     @LastModifiedDate
     @Comment("수정 일자")
-    @Column(name = "UPDATE_DATE")
+    @Column(name = "updated_date")
     private LocalDateTime updatedDate;
 
     //    @LastModifiedBy


### PR DESCRIPTION
## 📌 주요 변경 사항
- AuditInformation 클래스 필드의 매핑되는 테이블 칼럼명 소문자로 변경

---

## 📝 코멘트
- 칼럼명 소문자로 변경
- 필드명, 컬럼명을 과거형으로 상태유지


