### PR TITLE
feat: #45 토큰을 필요로하는 요청에서 토큰 검증하는 filter 추가하기

### DIFF
--- a/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
@@ -5,6 +5,7 @@ import com.moyorak.api.restaurant.dto.RestaurantSearchRequest;
 import com.moyorak.api.restaurant.service.RestaurantService;
 import com.moyorak.global.domain.ListResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/restaurants")
+@SecurityRequirement(name = "JWT")
 @Tag(name = "음식점 API", description = "음식점 API 입니다.")
 class RestaurantController {
 

--- a/src/main/java/com/moyorak/api/sample/controller/SampleController.java
+++ b/src/main/java/com/moyorak/api/sample/controller/SampleController.java
@@ -7,6 +7,7 @@ import com.moyorak.api.sample.dto.SampleUpdateRequest;
 import com.moyorak.api.sample.service.SampleService;
 import com.moyorak.global.domain.ListResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/sample")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
 @Tag(name = "샘플 API", description = "샘플용 API 입니다.")
 class SampleController {
 

--- a/src/main/java/com/moyorak/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/moyorak/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.moyorak.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+@RequiredArgsConstructor
+class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+
+        final ProblemDetail detail =
+                ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(detail));
+    }
+}

--- a/src/main/java/com/moyorak/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/moyorak/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.moyorak.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@RequiredArgsConstructor
+class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException, ServletException {
+
+        final ProblemDetail detail =
+                ProblemDetail.forStatusAndDetail(
+                        HttpStatus.UNAUTHORIZED, authException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(detail));
+    }
+}

--- a/src/main/java/com/moyorak/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/moyorak/config/security/CustomAuthenticationEntryPoint.java
@@ -12,7 +12,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
+@Component
 @RequiredArgsConstructor
 class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 

--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -59,6 +59,7 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         final String uri = request.getRequestURI();
 
+        // TODO: 이후, 인증 요청이 필요 없는 path의 경우 아래 추가가 필요합니다.
         return uri.startsWith("/swagger-ui")
                 || uri.startsWith("/v3/api-docs")
                 || uri.startsWith("/h2-console")

--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -19,6 +19,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String JWT_TOKEN_PREFIX = "Bearer ";
+
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationEntryPoint authenticationEntryPoint;
 
@@ -27,12 +29,18 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        final String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         try {
-            if (ObjectUtils.isEmpty(token)) {
+            if (ObjectUtils.isEmpty(authorization)) {
                 throw new AuthenticationCredentialsNotFoundException("로그인 정보가 없습니다.");
             }
+
+            if (!authorization.startsWith(JWT_TOKEN_PREFIX)) {
+                throw new BadCredentialsException("잘못된 요청입니다.");
+            }
+
+            final String token = authorization.substring(JWT_TOKEN_PREFIX.length());
 
             if (!jwtTokenProvider.isValidToken(token)) {
                 throw new BadCredentialsException("잘못된 요청입니다.");
@@ -45,5 +53,15 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (AuthenticationException e) {
             authenticationEntryPoint.commence(request, response, e);
         }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        final String uri = request.getRequestURI();
+
+        return uri.startsWith("/swagger-ui")
+                || uri.startsWith("/v3/api-docs")
+                || uri.startsWith("/h2-console")
+                || uri.equals("/favicon.ico");
     }
 }

--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -1,19 +1,18 @@
 package com.moyorak.config.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ProblemDetail;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -21,8 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-
-    private final ObjectMapper objectMapper;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
 
     @Override
     protected void doFilterInternal(
@@ -31,33 +29,21 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         final String token = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (ObjectUtils.isEmpty(token)) {
-            createResponse(
-                    response,
-                    ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "로그인 정보가 없습니다."));
+        try {
+            if (ObjectUtils.isEmpty(token)) {
+                throw new AuthenticationCredentialsNotFoundException("로그인 정보가 없습니다.");
+            }
 
-            return;
+            if (!jwtTokenProvider.isValidToken(token)) {
+                throw new BadCredentialsException("잘못된 요청입니다.");
+            }
+
+            final Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException e) {
+            authenticationEntryPoint.commence(request, response, e);
         }
-
-        if (!jwtTokenProvider.isValidToken(token)) {
-            createResponse(
-                    response,
-                    ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "잘못된 요청입니다."));
-
-            return;
-        }
-
-        final Authentication authentication = jwtTokenProvider.getAuthentication(token);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        filterChain.doFilter(request, response);
-    }
-
-    private void createResponse(HttpServletResponse response, ProblemDetail problemDetail)
-            throws IOException {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
     }
 }

--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.moyorak.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (ObjectUtils.isEmpty(token)) {
+            createResponse(
+                    response,
+                    ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "로그인 정보가 없습니다."));
+
+            return;
+        }
+
+        if (!jwtTokenProvider.isValidToken(token)) {
+            createResponse(
+                    response,
+                    ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "잘못된 요청입니다."));
+
+            return;
+        }
+
+        final Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void createResponse(HttpServletResponse response, ProblemDetail problemDetail)
+            throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+    }
+}

--- a/src/main/java/com/moyorak/config/security/SecurityConfig.java
+++ b/src/main/java/com/moyorak/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.moyorak.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,8 +14,12 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 class SecurityConfig {
 
+    private final JwtTokenProvider jwtTokenProvider;
+
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
     private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http, CustomOAuth2UserService oAuth2UserService)
@@ -42,7 +47,14 @@ class SecurityConfig {
                                 oauth.userInfoEndpoint(
                                                 userInfo -> userInfo.userService(oAuth2UserService))
                                         .successHandler(customOAuth2SuccessHandler)
-                                        .failureHandler(customOAuth2FailureHandler));
+                                        .failureHandler(customOAuth2FailureHandler))
+                .exceptionHandling(
+                        ex -> {
+                            ex.authenticationEntryPoint(
+                                            new CustomAuthenticationEntryPoint(objectMapper))
+                                    .accessDeniedHandler(
+                                            new CustomAccessDeniedHandler(objectMapper));
+                        });
 
         return http.build();
     }

--- a/src/main/java/com/moyorak/config/security/SecurityConfig.java
+++ b/src/main/java/com/moyorak/config/security/SecurityConfig.java
@@ -9,12 +9,15 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
     private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
@@ -49,12 +52,13 @@ class SecurityConfig {
                                         .successHandler(customOAuth2SuccessHandler)
                                         .failureHandler(customOAuth2FailureHandler))
                 .exceptionHandling(
-                        ex -> {
-                            ex.authenticationEntryPoint(
-                                            new CustomAuthenticationEntryPoint(objectMapper))
-                                    .accessDeniedHandler(
-                                            new CustomAccessDeniedHandler(objectMapper));
-                        });
+                        ex ->
+                                ex.authenticationEntryPoint(authenticationEntryPoint)
+                                        .accessDeniedHandler(
+                                                new CustomAccessDeniedHandler(objectMapper)))
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider, authenticationEntryPoint),
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/moyorak/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/moyorak/infra/swagger/SwaggerConfig.java
@@ -1,11 +1,18 @@
 package com.moyorak.infra.swagger;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+        name = "JWT",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT")
 class SwaggerConfig {
 
     @Bean

--- a/src/test/java/com/moyorak/config/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/moyorak/config/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,106 @@
+package com.moyorak.config.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moyorak.api.auth.domain.UserPrincipal;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class JwtAuthenticationFilterTest {
+
+    private final JwtTokenProvider jwtTokenProvider =
+            new JwtTokenProvider(new JwtTokenProperties("this-is-a-longer-test-secret-key-123456"));
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter =
+            new JwtAuthenticationFilter(jwtTokenProvider, objectMapper);
+
+    @Nested
+    @DisplayName("요청의 토큰이 유효한지 검증할 때,")
+    class requestCheck {
+
+        @Test
+        @DisplayName("토큰이 비어 있으면, 401를 반환합니다.")
+        void isEmpty() throws ServletException, IOException {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(response.getStatus())
+                                .isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                        it.assertThat(getResponseMessage(response)).contains("로그인 정보가 없습니다.");
+                    });
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 토큰으로 요청하게 되면, 401를 반환합니다.")
+        void isValid() throws ServletException, IOException {
+            // given
+            final String token = "INVALID-TOKEN";
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader(HttpHeaders.AUTHORIZATION, token);
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(response.getStatus())
+                                .isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                        it.assertThat(getResponseMessage(response)).contains("잘못된 요청입니다.");
+                    });
+        }
+
+        @Test
+        @DisplayName("유효한 토큰이 들어왔을 때, 인증에 성공합니다.")
+        void success() throws ServletException, IOException {
+            // given
+            final String token =
+                    jwtTokenProvider.generateAccessToken(
+                            UserPrincipal.generate(1L, "test@test.com", "홍길동"));
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader(HttpHeaders.AUTHORIZATION, token);
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        }
+    }
+
+    private static String getResponseMessage(MockHttpServletResponse response) {
+        try {
+            return response.getContentAsString();
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/moyorak/config/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/moyorak/config/security/JwtAuthenticationFilterTest.java
@@ -22,9 +22,11 @@ class JwtAuthenticationFilterTest {
     private final JwtTokenProvider jwtTokenProvider =
             new JwtTokenProvider(new JwtTokenProperties("this-is-a-longer-test-secret-key-123456"));
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint =
+            new CustomAuthenticationEntryPoint(objectMapper);
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter =
-            new JwtAuthenticationFilter(jwtTokenProvider, objectMapper);
+            new JwtAuthenticationFilter(jwtTokenProvider, authenticationEntryPoint);
 
     @Nested
     @DisplayName("요청의 토큰이 유효한지 검증할 때,")


### PR DESCRIPTION
## 📌 주요 변경 사항
JWT 형식을 이용하여 인증을 하기 위해서는, Filter 단에서 JWT 토큰이 유효한지 판단하기 위해
검증용 Filter를 추가하였습니다.

관련하여 Swagger 설정 및 시큐리티 설정도 함께 수정하였습니다.

해당 PR이 머지가 되면, 아래와 같은 사항을 참고해주세요.
1. 시큐리티와 별개로 인증이 불필요한 Path의 경우 Filter에 함께 제외를 해야 합니다.
2. 인증이 필요한 API의 경우, 클래스 혹은 메서드 상단에 `@SecurityRequirement(name = "JWT")`를 명시해주세요.
    아래와 같은 인증 요청이 ui 형식으로 보여지게 됩니다.
    ![image](https://github.com/user-attachments/assets/27f36ae0-541a-46b2-b250-2a65bf0cbb17)

---

## 📝 코멘트
- JWT 검증을 위한 Filter 추가
- 시큐리티 `authenticationEntryPoint`, `accessDeniedHandler` 추가
- Swagger 토큰 입력 설정 추가
