### PR TITLE
feat: #49 시큐리티 컨텍스트를 이용하여 작성자, 수정자 정보 사용할 수 있도록 AuditorAware 구현

### DIFF
--- a/src/main/java/com/moyorak/infra/orm/AuditInformation.java
+++ b/src/main/java/com/moyorak/infra/orm/AuditInformation.java
@@ -6,7 +6,9 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -20,18 +22,18 @@ public abstract class AuditInformation {
     @Column(name = "created_date", nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
-    //    @CreatedBy
-    //    @Comment("생성자")
-    //    @Column(name = "CREATED_ID", nullable = false, updatable = false)
-    //    private Long createdId;
+    @CreatedBy
+    @Comment("생성자")
+    @Column(name = "created_id", nullable = false, updatable = false)
+    private Long createdId;
 
     @LastModifiedDate
     @Comment("수정 일자")
     @Column(name = "updated_date")
     private LocalDateTime updatedDate;
 
-    //    @LastModifiedBy
-    //    @Comment("수정자")
-    //    @Column(name = "UPDATE_ID")
-    //    private Long updatedId;
+    @LastModifiedBy
+    @Comment("수정자")
+    @Column(name = "updated_id")
+    private Long updatedId;
 }

--- a/src/main/java/com/moyorak/infra/orm/SecurityAuditorAware.java
+++ b/src/main/java/com/moyorak/infra/orm/SecurityAuditorAware.java
@@ -1,0 +1,31 @@
+package com.moyorak.infra.orm;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+@Component
+class SecurityAuditorAware implements AuditorAware<Long> {
+
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        final Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+
+        if (ObjectUtils.isEmpty(authentication) || !authentication.isAuthenticated()) {
+            return Optional.of(0L);
+        }
+
+        final UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+
+        if (!ObjectUtils.isEmpty(principal)) {
+            return Optional.of(principal.getId());
+        }
+
+        return Optional.of(0L);
+    }
+}

--- a/src/test/java/com/moyorak/infra/orm/SecurityAuditorAwareTest.java
+++ b/src/test/java/com/moyorak/infra/orm/SecurityAuditorAwareTest.java
@@ -1,0 +1,74 @@
+package com.moyorak.infra.orm;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class SecurityAuditorAwareTest {
+
+    private final SecurityAuditorAware auditorAware = new SecurityAuditorAware();
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없을 경우 기본 값으로 반환됩니다.")
+    void isNotAuthentication() {
+        // given
+        final Long expectedResult = 0L;
+
+        SecurityContextHolder.createEmptyContext();
+
+        // when
+        final Long result = auditorAware.getCurrentAuditor().get();
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    @DisplayName("인증에 실패했을 경우에는 기본 값으로 반환합니다.")
+    void isUnauthenticated() {
+        // given
+        final Long expectedResult = 0L;
+
+        final Long userId = 99L;
+        final UserPrincipal userPrincipal = UserPrincipal.generate(userId, "", "");
+        final Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userPrincipal, "");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        final Long result = auditorAware.getCurrentAuditor().get();
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    @DisplayName("인증에 성공했을 경우, 인증 요청한 회원의 ID가 정상적으로 반환됩니다.")
+    void success() {
+        // given
+        final Long userId = 99L;
+        final UserPrincipal userPrincipal = UserPrincipal.generate(userId, "", "");
+        final Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userPrincipal, "", userPrincipal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        final Long result = auditorAware.getCurrentAuditor().get();
+
+        // then
+        assertThat(result).isEqualTo(userId);
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
시큐리티를 구현하여, JPA의 `Auditing` 기능을 사용하고자
시큐리티 컨텍스트에서 현재 인증 받은 회원 ID를 가져올 수 있도록 `AuditorAware`를 구현하였습니다.

---

## 📝 코멘트
- AuditorAware 구현체 작성
