### PR TITLE
feat: #53 최초 회원 가입의 경우 기본 정보를 반환한다

### DIFF
--- a/src/main/java/com/moyorak/api/auth/domain/User.java
+++ b/src/main/java/com/moyorak/api/auth/domain/User.java
@@ -32,14 +32,20 @@ public class User extends AuditInformation {
     @Column(name = "name", nullable = false, columnDefinition = "varchar(32)")
     private String name;
 
+    @Comment("프로필 이미지 URL")
+    @Column(name = "profile_image", nullable = false, columnDefinition = "varchar(256)")
+    private String profileImage;
+
     @Builder(access = AccessLevel.PRIVATE)
-    protected User(Long id, String email, String name) {
+    protected User(Long id, String email, String name, String profileImage) {
         this.id = id;
         this.email = email;
         this.name = name;
+        this.profileImage = profileImage;
     }
 
-    public static User registeredUser(final String email, final String name) {
-        return User.builder().email(email).name(name).build();
+    public static User registeredUser(
+            final String email, final String name, final String profileImage) {
+        return User.builder().email(email).name(name).profileImage(profileImage).build();
     }
 }

--- a/src/main/java/com/moyorak/api/auth/dto/SignUpResponse.java
+++ b/src/main/java/com/moyorak/api/auth/dto/SignUpResponse.java
@@ -1,0 +1,7 @@
+package com.moyorak.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[회원가입] 간편 회원가입 완료 응답 DTO")
+public record SignUpResponse(
+        @Schema(description = "회원 고유 ID") Long id, @Schema(description = "회원 이름") String name) {}

--- a/src/main/java/com/moyorak/config/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/moyorak/config/security/CustomOAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package com.moyorak.config.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.dto.SignInResponse;
+import com.moyorak.api.auth.dto.SignUpResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -31,6 +32,19 @@ class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
         final String email = oAuth2User.getAttribute("email");
         final String name = oAuth2User.getAttribute("name");
         final Long id = oAuth2User.getAttribute("id");
+
+        final Boolean isNew = oAuth2User.getAttribute("isNew");
+
+        if (isNew) {
+            final SignUpResponse signUpResponse = new SignUpResponse(id, name);
+
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.getWriter().write(objectMapper.writeValueAsString(signUpResponse));
+
+            return;
+        }
 
         final String token =
                 jwtTokenProvider.generateAccessToken(UserPrincipal.generate(id, email, name));

--- a/src/main/java/com/moyorak/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/moyorak/config/security/CustomOAuth2UserService.java
@@ -33,6 +33,8 @@ class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OA
         final String provider = userRequest.getClientRegistration().getRegistrationId();
         validProvider(provider);
 
+        final String picture = oauth2User.getAttribute("picture");
+
         // 현재는 회원 가입 정보가 없으면 즉시 회원 가입이 됩니다.
         // TODO: 회원 가입 정책이 정해지면 이 부분을 수정합니다.
         final User user =
@@ -40,7 +42,7 @@ class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OA
                         .findByEmail(email)
                         .orElseGet(
                                 () -> {
-                                    final User newUser = User.registeredUser(email, name);
+                                    final User newUser = User.registeredUser(email, name, picture);
 
                                     return userRepository.save(newUser);
                                 });


### PR DESCRIPTION
## 📌 주요 변경 사항
`CustomOAuth2UserService`에서 프로필 사진 정보를 가져오고, 
이미 회원의 경우 `isNew` 값을 false로
신규 회원일 때에는 `isNew` 값을 true로 return합니다.

`CustomOAuth2SuccessHandler`에서 `isNew` 값을 통해 분기 처리 합니다.

---

## 📝 코멘트
- 프로필 사진 저장하도록 추가
- isNew 구분 값 추가