### PR TITLE
feat: #50 토큰 저장 기능 추가

### DIFF
--- a/src/main/java/com/moyorak/api/auth/controller/TokenController.java
+++ b/src/main/java/com/moyorak/api/auth/controller/TokenController.java
@@ -1,0 +1,27 @@
+package com.moyorak.api.auth.controller;
+
+import com.moyorak.api.auth.dto.SignInRequest;
+import com.moyorak.api.auth.dto.SignInResponse;
+import com.moyorak.api.auth.service.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/token")
+@RequiredArgsConstructor
+@Tag(name = "[회원] [토큰] 토큰 관리 API", description = "토큰 관리를 위한 API 입니다.")
+class TokenController {
+
+    private final TokenService tokenService;
+
+    @PostMapping
+    @Operation(summary = "[로그인] 토큰 발급", description = "로그인을 하여 토큰을 발급 받습니다.")
+    public SignInResponse generateToken(@RequestBody final SignInRequest request) {
+        return tokenService.generate(request.userId());
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/domain/User.java
+++ b/src/main/java/com/moyorak/api/auth/domain/User.java
@@ -32,14 +32,20 @@ public class User extends AuditInformation {
     @Column(name = "name", nullable = false, columnDefinition = "varchar(32)")
     private String name;
 
+    @Comment("프로필 이미지 URL")
+    @Column(name = "profile_image", nullable = false, columnDefinition = "varchar(256)")
+    private String profileImage;
+
     @Builder(access = AccessLevel.PRIVATE)
-    protected User(Long id, String email, String name) {
+    protected User(Long id, String email, String name, String profileImage) {
         this.id = id;
         this.email = email;
         this.name = name;
+        this.profileImage = profileImage;
     }
 
-    public static User registeredUser(final String email, final String name) {
-        return User.builder().email(email).name(name).build();
+    public static User registeredUser(
+            final String email, final String name, final String profileImage) {
+        return User.builder().email(email).name(name).profileImage(profileImage).build();
     }
 }

--- a/src/main/java/com/moyorak/api/auth/domain/UserToken.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserToken.java
@@ -34,4 +34,13 @@ public class UserToken extends AuditInformation {
     @Comment("리프레시 토큰")
     @Column(name = "refresh_token", columnDefinition = "varchar(256)")
     private String refreshToken;
+
+    public static UserToken create(final Long userId, final String accessToken) {
+        UserToken userToken = new UserToken();
+
+        userToken.userId = userId;
+        userToken.accessToken = accessToken;
+
+        return userToken;
+    }
 }

--- a/src/main/java/com/moyorak/api/auth/domain/UserToken.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserToken.java
@@ -1,0 +1,37 @@
+package com.moyorak.api.auth.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "member_login_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserToken extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @Comment("회원 고유 ID")
+    @Column(name = "member_id", nullable = false, columnDefinition = "bigint")
+    private Long userId;
+
+    @Comment("액세스 토큰")
+    @Column(name = "access_token", columnDefinition = "varchar(256)")
+    private String accessToken;
+
+    @Comment("리프레시 토큰")
+    @Column(name = "refresh_token", columnDefinition = "varchar(256)")
+    private String refreshToken;
+}

--- a/src/main/java/com/moyorak/api/auth/dto/SignInRequest.java
+++ b/src/main/java/com/moyorak/api/auth/dto/SignInRequest.java
@@ -1,11 +1,8 @@
 package com.moyorak.api.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(title = "[로그인] 로그인 요청 DTO")
 public record SignInRequest(
-        @NotNull @Schema(description = "회원 고유 ID", example = "13") Long userId,
-        @NotBlank @Schema(description = "이메일", example = "honggildong@gmail.com") String email,
-        @NotBlank @Schema(description = "회원 이름", example = "홍길동") String name) {}
+        @NotNull @Schema(description = "회원 고유 ID", example = "13") Long userId) {}

--- a/src/main/java/com/moyorak/api/auth/dto/SignInRequest.java
+++ b/src/main/java/com/moyorak/api/auth/dto/SignInRequest.java
@@ -1,0 +1,11 @@
+package com.moyorak.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(title = "[로그인] 로그인 요청 DTO")
+public record SignInRequest(
+        @NotNull @Schema(description = "회원 고유 ID", example = "13") Long userId,
+        @NotBlank @Schema(description = "이메일", example = "honggildong@gmail.com") String email,
+        @NotBlank @Schema(description = "회원 이름", example = "홍길동") String name) {}

--- a/src/main/java/com/moyorak/api/auth/dto/SignUpResponse.java
+++ b/src/main/java/com/moyorak/api/auth/dto/SignUpResponse.java
@@ -1,0 +1,7 @@
+package com.moyorak.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[회원가입] 간편 회원가입 완료 응답 DTO")
+public record SignUpResponse(
+        @Schema(description = "회원 고유 ID") Long id, @Schema(description = "회원 이름") String name) {}

--- a/src/main/java/com/moyorak/api/auth/repository/TokenRepository.java
+++ b/src/main/java/com/moyorak/api/auth/repository/TokenRepository.java
@@ -1,0 +1,6 @@
+package com.moyorak.api.auth.repository;
+
+import com.moyorak.api.auth.domain.UserToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenRepository extends CrudRepository<UserToken, Long> {}

--- a/src/main/java/com/moyorak/api/auth/service/TokenService.java
+++ b/src/main/java/com/moyorak/api/auth/service/TokenService.java
@@ -1,9 +1,12 @@
 package com.moyorak.api.auth.service;
 
+import com.moyorak.api.auth.domain.User;
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.domain.UserToken;
 import com.moyorak.api.auth.dto.SignInResponse;
 import com.moyorak.api.auth.repository.TokenRepository;
+import com.moyorak.api.auth.repository.UserRepository;
+import com.moyorak.config.exception.BusinessException;
 import com.moyorak.config.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +18,19 @@ public class TokenService {
 
     private final TokenRepository tokenRepository;
 
+    private final UserRepository userRepository;
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public SignInResponse generate(final Long userId, final String email, final String name) {
-        final UserPrincipal userPrincipal = UserPrincipal.generate(userId, email, name);
+    public SignInResponse generate(final Long userId) {
+        final User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new BusinessException("유효하지 않은 회원 ID 입니다."));
+
+        final UserPrincipal userPrincipal =
+                UserPrincipal.generate(userId, user.getEmail(), user.getName());
 
         final String token = jwtTokenProvider.generateAccessToken(userPrincipal);
 

--- a/src/main/java/com/moyorak/api/auth/service/TokenService.java
+++ b/src/main/java/com/moyorak/api/auth/service/TokenService.java
@@ -1,0 +1,30 @@
+package com.moyorak.api.auth.service;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.auth.domain.UserToken;
+import com.moyorak.api.auth.dto.SignInResponse;
+import com.moyorak.api.auth.repository.TokenRepository;
+import com.moyorak.config.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public SignInResponse generate(final Long userId, final String email, final String name) {
+        final UserPrincipal userPrincipal = UserPrincipal.generate(userId, email, name);
+
+        final String token = jwtTokenProvider.generateAccessToken(userPrincipal);
+
+        tokenRepository.save(UserToken.create(userId, token));
+
+        return new SignInResponse(token);
+    }
+}

--- a/src/main/java/com/moyorak/config/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/moyorak/config/security/CustomOAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package com.moyorak.config.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.dto.SignInResponse;
+import com.moyorak.api.auth.dto.SignUpResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -31,6 +32,19 @@ class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
         final String email = oAuth2User.getAttribute("email");
         final String name = oAuth2User.getAttribute("name");
         final Long id = oAuth2User.getAttribute("id");
+
+        final Boolean isNew = oAuth2User.getAttribute("isNew");
+
+        if (isNew) {
+            final SignUpResponse signUpResponse = new SignUpResponse(id, name);
+
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.getWriter().write(objectMapper.writeValueAsString(signUpResponse));
+
+            return;
+        }
 
         final String token =
                 jwtTokenProvider.generateAccessToken(UserPrincipal.generate(id, email, name));

--- a/src/main/java/com/moyorak/config/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/moyorak/config/security/CustomOAuth2SuccessHandler.java
@@ -1,9 +1,9 @@
 package com.moyorak.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.dto.SignInResponse;
 import com.moyorak.api.auth.dto.SignUpResponse;
+import com.moyorak.api.auth.service.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -29,7 +29,6 @@ class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         final OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        final String email = oAuth2User.getAttribute("email");
         final String name = oAuth2User.getAttribute("name");
         final Long id = oAuth2User.getAttribute("id");
 
@@ -46,10 +45,7 @@ class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
             return;
         }
 
-        final String token =
-                jwtTokenProvider.generateAccessToken(UserPrincipal.generate(id, email, name));
-
-        final SignInResponse signInResponse = new SignInResponse(token);
+        final SignInResponse signInResponse = tokenService.generate(id);
 
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/moyorak/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/moyorak/config/security/CustomOAuth2UserService.java
@@ -33,6 +33,8 @@ class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OA
         final String provider = userRequest.getClientRegistration().getRegistrationId();
         validProvider(provider);
 
+        final String picture = oauth2User.getAttribute("picture");
+
         // 현재는 회원 가입 정보가 없으면 즉시 회원 가입이 됩니다.
         // TODO: 회원 가입 정책이 정해지면 이 부분을 수정합니다.
         final User user =
@@ -40,7 +42,7 @@ class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OA
                         .findByEmail(email)
                         .orElseGet(
                                 () -> {
-                                    final User newUser = User.registeredUser(email, name);
+                                    final User newUser = User.registeredUser(email, name, picture);
 
                                     return userRepository.save(newUser);
                                 });

--- a/src/main/java/com/moyorak/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/moyorak/config/security/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-class JwtTokenProvider {
+public class JwtTokenProvider {
 
     // TODO: 테스트를 위해 시간 짧게 유지 해야한다면, 환경 변수 처리가 필요합니다.
     private static final long EXPIRATION_MILLIS = 1000 * 60 * 60;

--- a/src/test/java/com/moyorak/api/auth/domain/UserFixture.java
+++ b/src/test/java/com/moyorak/api/auth/domain/UserFixture.java
@@ -1,0 +1,18 @@
+package com.moyorak.api.auth.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class UserFixture {
+
+    public static User fixture(
+            final Long id, final String email, final String name, final String profileImage) {
+        User user = new User();
+
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "email", email);
+        ReflectionTestUtils.setField(user, "name", name);
+        ReflectionTestUtils.setField(user, "profileImage", profileImage);
+
+        return user;
+    }
+}

--- a/src/test/java/com/moyorak/api/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/moyorak/api/auth/service/TokenServiceTest.java
@@ -1,14 +1,20 @@
 package com.moyorak.api.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.moyorak.api.auth.domain.User;
+import com.moyorak.api.auth.domain.UserFixture;
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.domain.UserToken;
 import com.moyorak.api.auth.dto.SignInResponse;
 import com.moyorak.api.auth.repository.TokenRepository;
+import com.moyorak.api.auth.repository.UserRepository;
+import com.moyorak.config.exception.BusinessException;
 import com.moyorak.config.security.JwtTokenProvider;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,11 +30,28 @@ class TokenServiceTest {
 
     @Mock private TokenRepository tokenRepository;
 
+    @Mock private UserRepository userRepository;
+
     @Mock private JwtTokenProvider jwtTokenProvider;
 
     @Nested
     @DisplayName("토큰을 발급 받을 때,")
     class generate {
+
+        @Test
+        @DisplayName("유효하지 않은 회원 ID의 경우 에러가 발생합니다.")
+        void invalidUserId() {
+            // given
+            final Long userId = 1L;
+
+            given(userRepository.findById(userId))
+                    .willThrow(new BusinessException("유효하지 않은 회원 ID 입니다."));
+
+            // when & then
+            assertThatThrownBy(() -> tokenService.generate(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("유효하지 않은 회원 ID 입니다.");
+        }
 
         @Test
         @DisplayName("성공적으로 발급 받습니다.")
@@ -38,14 +61,16 @@ class TokenServiceTest {
             final String email = "gildong@gmail.com";
             final String name = "홍길동";
 
+            final User expectedUser = UserFixture.fixture(userId, email, name, "");
             final String token = "TOKEN-EXAMPLE";
             final UserToken expectedUserToken = UserToken.create(userId, token);
 
+            given(userRepository.findById(userId)).willReturn(Optional.of(expectedUser));
             given(jwtTokenProvider.generateAccessToken(any(UserPrincipal.class))).willReturn(token);
             given(tokenRepository.save(any(UserToken.class))).willReturn(expectedUserToken);
 
             // when
-            final SignInResponse result = tokenService.generate(userId, email, name);
+            final SignInResponse result = tokenService.generate(userId);
 
             // then
             assertThat(result.accessToken()).isEqualTo(token);

--- a/src/test/java/com/moyorak/api/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/moyorak/api/auth/service/TokenServiceTest.java
@@ -1,0 +1,54 @@
+package com.moyorak.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.auth.domain.UserToken;
+import com.moyorak.api.auth.dto.SignInResponse;
+import com.moyorak.api.auth.repository.TokenRepository;
+import com.moyorak.config.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @InjectMocks private TokenService tokenService;
+
+    @Mock private TokenRepository tokenRepository;
+
+    @Mock private JwtTokenProvider jwtTokenProvider;
+
+    @Nested
+    @DisplayName("토큰을 발급 받을 때,")
+    class generate {
+
+        @Test
+        @DisplayName("성공적으로 발급 받습니다.")
+        void success() {
+            // given
+            final Long userId = 1L;
+            final String email = "gildong@gmail.com";
+            final String name = "홍길동";
+
+            final String token = "TOKEN-EXAMPLE";
+            final UserToken expectedUserToken = UserToken.create(userId, token);
+
+            given(jwtTokenProvider.generateAccessToken(any(UserPrincipal.class))).willReturn(token);
+            given(tokenRepository.save(any(UserToken.class))).willReturn(expectedUserToken);
+
+            // when
+            final SignInResponse result = tokenService.generate(userId, email, name);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo(token);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
⚠️ #54 가 선행 되어야 합니다.

토큰 발급을 별도 Service에서 처리할 수 있도록 `TokenService`를 생성하였습니다.

refresh 토큰은 이후 추가 예정입니다.

---

## 📝 코멘트
- Token Entity 생성
- 회원 id 검증 후 유효한 경우에만 토큰 발급 받을 수 있도록 기능 추가
- `CustomOAuth2SuccessHandler`에서 토큰 발급 받던 것을 `TokenService`로 분리
- 테스트 로그인 용 API 추가
