### PR TITLE
chore: #58 로그인 요청 시 JWT 필터에서 제외 되도록 조건 추가

### DIFF
--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -54,4 +54,11 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
             authenticationEntryPoint.commence(request, response, e);
         }
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        final String uri = request.getRequestURI();
+
+        return uri.startsWith("/api/auth/sign-in");
+    }
 }

--- a/src/test/java/com/moyorak/config/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/moyorak/config/security/JwtAuthenticationFilterTest.java
@@ -127,6 +127,37 @@ class JwtAuthenticationFilterTest {
         }
     }
 
+    @Nested
+    @DisplayName("특정 URI 경우 JWT 필터에 적용되지 않게 할 때,")
+    class shouldNotFilter {
+
+        @Test
+        @DisplayName("예외가 포함 되어 있으면 성공적으로 제외 된다.")
+        void isTrue() {
+            // given
+            MockHttpServletRequest request =
+                    new MockHttpServletRequest("POST", "/api/auth/sign-in");
+
+            // when
+            final Boolean result = jwtAuthenticationFilter.shouldNotFilter(request);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("예외에 포함되지 않을 경우 필터 처리를 위해 false가 응답 된다.")
+        void isFalse() {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/sample");
+
+            // when
+            final Boolean result = jwtAuthenticationFilter.shouldNotFilter(request);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
     private static String getResponseMessage(MockHttpServletResponse response) {
         try {
             return response.getContentAsString();


### PR DESCRIPTION
## 📌 주요 변경 사항
- 로그인의 경우 JWT 토큰이 없어 필터에서 처리 되지 않도록 예외 조건을 추가 하였습니다.

---

## 📝 코멘트
- `JwtAuthenticationFilter`에 `shouldNotFilter` 구현
- 테스트 코드 케이스 추가
