### PR TITLE
feat: #56 입력 된 토큰이 저장 된 토큰과 동일한지 검증한다

### DIFF
--- a/src/main/java/com/moyorak/api/auth/domain/InvalidTokenException.java
+++ b/src/main/java/com/moyorak/api/auth/domain/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package com.moyorak.api.auth.domain;
+
+import com.moyorak.config.exception.BusinessException;
+
+public class InvalidTokenException extends BusinessException {
+
+    public InvalidTokenException() {
+        super("유효하지 않은 로그인 정보입니다.");
+    }
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/domain/InvalidTokenException.java
+++ b/src/main/java/com/moyorak/api/auth/domain/InvalidTokenException.java
@@ -1,8 +1,8 @@
 package com.moyorak.api.auth.domain;
 
-import com.moyorak.config.exception.BusinessException;
+import org.springframework.security.authentication.BadCredentialsException;
 
-public class InvalidTokenException extends BusinessException {
+public class InvalidTokenException extends BadCredentialsException {
 
     public InvalidTokenException() {
         super("유효하지 않은 로그인 정보입니다.");

--- a/src/main/java/com/moyorak/api/auth/domain/UserToken.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserToken.java
@@ -52,4 +52,8 @@ public class UserToken extends AuditInformation {
     public void clear() {
         this.accessToken = null;
     }
+
+    public boolean isEqualsToken(final String token) {
+        return token.equals(this.accessToken);
+    }
 }

--- a/src/main/java/com/moyorak/api/auth/domain/UserToken.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserToken.java
@@ -54,6 +54,10 @@ public class UserToken extends AuditInformation {
     }
 
     public boolean isEqualsToken(final String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
         return token.equals(this.accessToken);
     }
 }

--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.moyorak.config.security;
 
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.auth.service.AuthService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,6 +26,8 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationEntryPoint authenticationEntryPoint;
 
+    private final AuthService authService;
+
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -47,6 +51,9 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             final Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            validToken(authentication, token);
+
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             filterChain.doFilter(request, response);
@@ -60,5 +67,10 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String uri = request.getRequestURI();
 
         return uri.startsWith("/api/auth/sign-in");
+    }
+
+    private void validToken(final Authentication authentication, final String token) {
+        final UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        authService.validToken(principal.getId(), token);
     }
 }

--- a/src/main/java/com/moyorak/config/security/SecurityConfig.java
+++ b/src/main/java/com/moyorak/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.moyorak.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moyorak.api.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,8 @@ class SecurityConfig {
 
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
     private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
+
+    private final AuthService authService;
 
     private final ObjectMapper objectMapper;
 
@@ -58,7 +61,8 @@ class SecurityConfig {
                                         .accessDeniedHandler(
                                                 new CustomAccessDeniedHandler(objectMapper)))
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider, authenticationEntryPoint),
+                        new JwtAuthenticationFilter(
+                                jwtTokenProvider, authenticationEntryPoint, authService),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/test/java/com/moyorak/api/auth/domain/UserTokenTest.java
+++ b/src/test/java/com/moyorak/api/auth/domain/UserTokenTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class UserTokenTest {
 
@@ -53,5 +56,53 @@ class UserTokenTest {
 
         // then
         assertThat(userToken.getAccessToken()).isNull();
+    }
+
+    @Nested
+    @DisplayName("입력 된 토큰과, 현재 토큰이 동일한지 확인할 때,")
+    class isEqualsToken {
+
+        @Test
+        @DisplayName("입력된 토큰이 null이면, false를 반환합니다.")
+        void isNull() {
+            // given
+            final String token = null;
+            final UserToken userToken = UserToken.create(1L, "EXAMPLE-TOKEN");
+
+            // when
+            final boolean result = userToken.isEqualsToken(token);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @ParameterizedTest
+        @EmptySource
+        @ValueSource(strings = " ")
+        @DisplayName("서로 토큰이 다르다면, false를 반환합니다.")
+        void notEquals(final String input) {
+            // given
+            final UserToken userToken = UserToken.create(1L, "EXAMPLE-TOKEN");
+
+            // when
+            final boolean result = userToken.isEqualsToken(input);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("동일한 경우, true를 반환합니다.")
+        void isEquals() {
+            // given
+            final String token = "EXAMPLE-TOKEN";
+            final UserToken userToken = UserToken.create(1L, token);
+
+            // when
+            final boolean result = userToken.isEqualsToken(token);
+
+            // then
+            assertThat(result).isTrue();
+        }
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 저장 된 토큰 정보와, 입력 된 토큰이 동일한지 비교하는 로직이 추가 되었습니다.

---

## 📝 코멘트
- 공통 된 로직 private 메서드로 분리
- BadCredentialsException 상속받는 InvalidTokenException 추가
   - 이를 통해, 토큰이 동일하지 않다면 시큐리티를 통해 401 응답 
- `AuthService`에 입력 토큰과 저장 토큰이 같은지 비교하는 메서드 추가
- JWT Filter 내에서 `AuthService` 호출하여 토큰 비교하도록 로직 추가
