### PR TITLE
chore: #86 회원 가입 통해서 회원 정보 저장을 하기 위해, 기존 Google OAuth2 조회 후 저장 하던 기능 제거

### DIFF
--- a/src/main/java/com/moyorak/api/auth/domain/UserPrincipal.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserPrincipal.java
@@ -16,6 +16,17 @@ public class UserPrincipal implements OAuth2User, UserDetails {
 
     private Map<String, Object> attributes;
 
+    public static UserPrincipal newUserGenerate(
+            final String email, final String name, final Map<String, Object> attributes) {
+        UserPrincipal userPrincipal = new UserPrincipal();
+
+        userPrincipal.email = email;
+        userPrincipal.name = name;
+        userPrincipal.attributes = attributes;
+
+        return userPrincipal;
+    }
+
     public static UserPrincipal generate(
             final Long id,
             final String email,

--- a/src/main/java/com/moyorak/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/moyorak/config/security/CustomOAuth2UserService.java
@@ -46,11 +46,9 @@ class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OA
             return UserPrincipal.generate(user.get().getId(), email, name, attributes);
         }
 
-        final User newUser = userRepository.save(User.registeredUser(email, name, picture));
-
         attributes.put("isNew", true);
 
-        return UserPrincipal.generate(newUser.getId(), email, name, attributes);
+        return UserPrincipal.newUserGenerate(email, name, attributes);
     }
 
     private void validEmail(final String email) {


### PR DESCRIPTION
## 📌 주요 변경 사항
기존 Google OAuth2에서 정보 조회 후, 신규 회원의 경우 바로 회원 테이블에 INSERT 했으나,
회원 가입 API 를 통해서만 회원 테이블에 데이터가 적재될 수 있도록 변경하고자 합니다.

---

## 📝 코멘트
- `CustomOAuth2UserService` 에서 회원 정보 저장하는 부분 제거
