### PR TITLE
feat: #90 카카오 api 조회 수정

### DIFF
--- a/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
@@ -26,7 +26,7 @@ class RestaurantController {
     private final RestaurantService restaurantService;
 
     @GetMapping
-    @Operation(summary = "음식점 데이터 조회", description = "음식점 데이터 리스트를 검색합니다.")
+    @Operation(summary = "음식점 데이터 조회 (카카오 api)", description = "음식점 데이터 리스트를 카카오 api를 통해 검색합니다.")
     public ListResponse<RestaurantResponse> searchRestaurants(
             @Valid RestaurantSearchRequest searchRequest) {
         return restaurantService.searchRestaurants(searchRequest);

--- a/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
@@ -25,7 +25,7 @@ class RestaurantController {
 
     private final RestaurantService restaurantService;
 
-    @GetMapping
+    @GetMapping("/kakao")
     @Operation(summary = "음식점 데이터 조회 (카카오 api)", description = "음식점 데이터 리스트를 카카오 api를 통해 검색합니다.")
     public ListResponse<RestaurantResponse> searchRestaurants(
             @Valid RestaurantSearchRequest searchRequest) {

--- a/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/moyorak/api/restaurant/controller/RestaurantController.java
@@ -25,8 +25,8 @@ class RestaurantController {
 
     private final RestaurantService restaurantService;
 
-    @GetMapping("/kakao")
-    @Operation(summary = "음식점 데이터 조회 (카카오 api)", description = "음식점 데이터 리스트를 카카오 api를 통해 검색합니다.")
+    @GetMapping("/external/search")
+    @Operation(summary = "음식점 데이터 검색 (카카오 api)", description = "음식점 데이터 리스트를 카카오 api를 통해 검색합니다.")
     public ListResponse<RestaurantResponse> searchRestaurants(
             @Valid RestaurantSearchRequest searchRequest) {
         return restaurantService.searchRestaurants(searchRequest);

--- a/src/main/java/com/moyorak/api/restaurant/dto/RestaurantResponse.java
+++ b/src/main/java/com/moyorak/api/restaurant/dto/RestaurantResponse.java
@@ -5,19 +5,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "음식점 정보 DTO")
 public record RestaurantResponse(
-        @Schema(description = "장소명", example = "곱창고 을지로점") String placeName,
-        @Schema(description = "전체 지번 주소", example = "서울 중구 을지로3가 95-1") String addressName,
-        @Schema(description = "전체 도로명 주소", example = "서울 중구 을지로 108") String roadAddressName,
-        @Schema(description = "전화번호", example = "02-1234-5678") String phone,
-        @Schema(description = "경도(Longitude, X좌표)", example = "126.990774") String x,
-        @Schema(description = "위도(Latitude, Y좌표)", example = "37.566345") String y) {
+        @Schema(description = "장소명", example = "곱창고 을지로점") String name,
+        @Schema(description = "장소 url", example = "http://place.map.kakao.com/26338954")
+                String placeUrl,
+        @Schema(description = "전체 지번 주소", example = "서울 중구 을지로3가 95-1") String address,
+        @Schema(description = "전체 도로명 주소", example = "서울 중구 을지로 108") String roadAddress,
+        @Schema(description = "경도", example = "126.990774") Double longitude,
+        @Schema(description = "위도", example = "37.566345") Double latitude) {
 
     public static RestaurantResponse fromKakaoPlace(KakaoPlace kakaoPlace) {
         return new RestaurantResponse(
                 kakaoPlace.placeName(),
+                kakaoPlace.placeUrl(),
                 kakaoPlace.addressName(),
                 kakaoPlace.roadAddressName(),
-                kakaoPlace.phone(),
                 kakaoPlace.x(),
                 kakaoPlace.y());
     }

--- a/src/main/java/com/moyorak/api/restaurant/dto/RestaurantSearchRequest.java
+++ b/src/main/java/com/moyorak/api/restaurant/dto/RestaurantSearchRequest.java
@@ -18,11 +18,11 @@ public record RestaurantSearchRequest(
         @DecimalMin(value = "-180.0", message = "경도는 {value} 이상이어야 합니다.")
                 @DecimalMax(value = "180.0", message = "경도는 {value} 이하여야 합니다.")
                 @Parameter(description = "경도", example = "127.043616")
-                Double x,
+                Double longitude,
         @DecimalMin(value = "-90.0", message = "위도는 {value} 이상이어야 합니다.")
                 @DecimalMax(value = "90.0", message = "위도는 {value} 이하여야 합니다.")
                 @Parameter(description = "위도", example = "37.279838")
-                Double y,
+                Double latitude,
         @Min(value = 0, message = "반경은 {value}m 이상이어야 합니다.")
                 @Max(value = 20000, message = "반경은 {value}m 이하여야 합니다.")
                 @Parameter(description = "조회 범위", example = "2000")
@@ -39,6 +39,6 @@ public record RestaurantSearchRequest(
     private static final String FOOD_CODE = "FD6";
 
     public KakaoSearchRequest toKakaoSearchRequest() {
-        return new KakaoSearchRequest(query, x, y, radius, page, size, FOOD_CODE);
+        return new KakaoSearchRequest(query, longitude, latitude, radius, page, size, FOOD_CODE);
     }
 }

--- a/src/main/java/com/moyorak/infra/client/kakao/KakaoClient.java
+++ b/src/main/java/com/moyorak/infra/client/kakao/KakaoClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestClient;
 
 @RequiredArgsConstructor
 @Slf4j
-public class KakoClient {
+public class KakaoClient {
 
     private final RestClient restClient;
 

--- a/src/main/java/com/moyorak/infra/client/kakao/KakaoClientConfig.java
+++ b/src/main/java/com/moyorak/infra/client/kakao/KakaoClientConfig.java
@@ -15,7 +15,7 @@ class KakaoClientConfig {
     private final RestClient.Builder restClientBuilder;
 
     @Bean
-    KakoClient kakoClient(
+    KakaoClient kakaoClient(
             @Value("${kakao.api.base-url}") final String baseUrl,
             @Value("${kakao.api.key}") final String apiKey) {
         RestClient restClient =
@@ -24,6 +24,6 @@ class KakaoClientConfig {
                         .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + apiKey)
                         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .build();
-        return new KakoClient(restClient);
+        return new KakaoClient(restClient);
     }
 }

--- a/src/main/java/com/moyorak/infra/client/kakao/KakaoSearcher.java
+++ b/src/main/java/com/moyorak/infra/client/kakao/KakaoSearcher.java
@@ -2,7 +2,7 @@ package com.moyorak.infra.client.kakao;
 
 import com.moyorak.infra.client.kakao.dto.KakaoPlace;
 import com.moyorak.infra.client.kakao.dto.KakaoSearchRequest;
-import com.moyorak.infra.client.kakao.dto.KakoSearchResponse;
+import com.moyorak.infra.client.kakao.dto.KakaoSearchResponse;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
@@ -16,7 +16,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class KakaoSearcher {
 
-    private final KakoClient kakoClient;
+    private final KakaoClient kakaoClient;
     private static final String KEYWORD_SEARCH_PATH = "/v2/local/search/keyword.json";
 
     public Page<KakaoPlace> search(KakaoSearchRequest kakaoSearchRequest) {
@@ -25,24 +25,25 @@ public class KakaoSearcher {
                         .queryParams(kakaoSearchRequest.toMultiValueMap())
                         .build()
                         .toUriString();
-        KakoSearchResponse kakoSearchResponse =
-                kakoClient.get(uri, new ParameterizedTypeReference<>() {});
-        return createPage(kakoSearchResponse, kakaoSearchRequest.page(), kakaoSearchRequest.size());
+        KakaoSearchResponse kakaoSearchResponse =
+                kakaoClient.get(uri, new ParameterizedTypeReference<>() {});
+        return createPage(
+                kakaoSearchResponse, kakaoSearchRequest.page(), kakaoSearchRequest.size());
     }
 
     private Page<KakaoPlace> createPage(
-            KakoSearchResponse kakoSearchResponse, int currentPage, int size) {
+            KakaoSearchResponse kakaoSearchResponse, int currentPage, int size) {
         int offset = (currentPage - 1) * size;
         PageRequest pageRequest = PageRequest.of(currentPage - 1, size);
-        if (offset >= kakoSearchResponse.meta().pageableCount()) {
+        if (offset >= kakaoSearchResponse.meta().pageableCount()) {
             return new PageImpl<>(
                     Collections.emptyList(),
                     pageRequest,
-                    kakoSearchResponse.meta().pageableCount());
+                    kakaoSearchResponse.meta().pageableCount());
         }
         return new PageImpl<>(
-                kakoSearchResponse.documents(),
+                kakaoSearchResponse.documents(),
                 pageRequest,
-                kakoSearchResponse.meta().pageableCount());
+                kakaoSearchResponse.meta().pageableCount());
     }
 }

--- a/src/main/java/com/moyorak/infra/client/kakao/dto/KakaoPlace.java
+++ b/src/main/java/com/moyorak/infra/client/kakao/dto/KakaoPlace.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record KakaoPlace(
         @JsonProperty("place_name") String placeName,
+        @JsonProperty("place_url") String placeUrl,
         @JsonProperty("address_name") String addressName,
         @JsonProperty("road_address_name") String roadAddressName,
-        @JsonProperty("phone") String phone,
-        @JsonProperty("x") String x,
-        @JsonProperty("y") String y) {}
+        @JsonProperty("x") Double x,
+        @JsonProperty("y") Double y) {}

--- a/src/main/java/com/moyorak/infra/client/kakao/dto/KakaoSearchResponse.java
+++ b/src/main/java/com/moyorak/infra/client/kakao/dto/KakaoSearchResponse.java
@@ -1,0 +1,5 @@
+package com.moyorak.infra.client.kakao.dto;
+
+import java.util.List;
+
+public record KakaoSearchResponse(List<KakaoPlace> documents, KakaoMeta meta) {}

--- a/src/main/java/com/moyorak/infra/client/kakao/dto/KakoSearchResponse.java
+++ b/src/main/java/com/moyorak/infra/client/kakao/dto/KakoSearchResponse.java
@@ -1,5 +1,0 @@
-package com.moyorak.infra.client.kakao.dto;
-
-import java.util.List;
-
-public record KakoSearchResponse(List<KakaoPlace> documents, KakaoMeta meta) {}

--- a/src/test/java/com/moyorak/infra/client/kakao/KakaoSearcherTest.java
+++ b/src/test/java/com/moyorak/infra/client/kakao/KakaoSearcherTest.java
@@ -1,0 +1,66 @@
+package com.moyorak.infra.client.kakao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.infra.client.kakao.dto.KakaoMeta;
+import com.moyorak.infra.client.kakao.dto.KakaoPlace;
+import com.moyorak.infra.client.kakao.dto.KakaoSearchRequest;
+import com.moyorak.infra.client.kakao.dto.KakaoSearchResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.domain.Page;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoSearcherTest {
+
+    @Mock private KakaoClient kakaoClient;
+
+    @InjectMocks private KakaoSearcher kakaoSearcher;
+
+    private static final String KEYWORD_SEARCH_PATH = "/v2/local/search/keyword.json";
+
+    @Nested
+    @DisplayName("카카오 api로 데이터를 조회할 때")
+    class Search {
+        @Test
+        @DisplayName("제공 가능한 데이터의 마지막 페이지를 초과하면 빈 리스트를 반환합니다.")
+        void isOverLimit() {
+            // given
+            final int page = 6;
+            final int size = 10;
+            final KakaoSearchRequest request =
+                    new KakaoSearchRequest("김밥", null, null, null, page, size, null);
+
+            final int maxAvailableResults = 45; // 실제 카카오가 제공 가능한 결과 수
+            final int totalCount = 500; // 카카오의 전체 데이터 수
+
+            final KakaoSearchResponse kakaoSearchResponse =
+                    new KakaoSearchResponse(
+                            List.of(), new KakaoMeta(totalCount, maxAvailableResults, true));
+
+            final String uri =
+                    UriComponentsBuilder.fromPath(KEYWORD_SEARCH_PATH)
+                            .queryParams(request.toMultiValueMap())
+                            .build()
+                            .toUriString();
+
+            given(kakaoClient.get(uri, new ParameterizedTypeReference<KakaoSearchResponse>() {}))
+                    .willReturn(kakaoSearchResponse);
+
+            // when
+            Page<KakaoPlace> result = kakaoSearcher.search(request);
+
+            // then
+            assertThat(result.getContent()).isNotNull().isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/moyorak/infra/client/kakao/dto/KakaoSearchResponseTest.java
+++ b/src/test/java/com/moyorak/infra/client/kakao/dto/KakaoSearchResponseTest.java
@@ -1,0 +1,69 @@
+package com.moyorak.infra.client.kakao.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KakaoSearchResponseTest {
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Test
+    @DisplayName("KakaoSearchResponse 역직렬화")
+    void success() throws JsonProcessingException {
+
+        // given
+        String json =
+                """
+            {
+              "meta": {
+                "same_name": {
+                  "region": [],
+                  "keyword": "카카오프렌즈",
+                  "selected_region": ""
+                },
+                "pageable_count": 14,
+                "total_count": 14,
+                "is_end": true
+              },
+              "documents": [
+                {
+                  "place_name": "카카오프렌즈 코엑스점",
+                  "distance": "418",
+                  "place_url": "http://place.map.kakao.com/26338954",
+                  "category_name": "가정,생활 > 문구,사무용품 > 디자인문구 > 카카오프렌즈",
+                  "address_name": "서울 강남구 삼성동 159",
+                  "road_address_name": "서울 강남구 영동대로 513",
+                  "id": "26338954",
+                  "phone": "02-6002-1880",
+                  "category_group_code": "",
+                  "category_group_name": "",
+                  "x": "127.05902969025047",
+                  "y": "37.51207412593136"
+                }
+              ]
+            }
+            """;
+
+        // when
+        KakaoSearchResponse kakaoSearchResponse =
+                objectMapper.readValue(json, KakaoSearchResponse.class);
+
+        assertThat(kakaoSearchResponse.meta().pageableCount()).isEqualTo(14);
+        assertThat(kakaoSearchResponse.meta().totalCount()).isEqualTo(14);
+        assertThat(kakaoSearchResponse.meta().isEnd()).isTrue();
+
+        KakaoPlace kakaoPlace = kakaoSearchResponse.documents().get(0);
+        assertThat(kakaoPlace.placeName()).isEqualTo("카카오프렌즈 코엑스점");
+        assertThat(kakaoPlace.placeUrl()).isEqualTo("http://place.map.kakao.com/26338954");
+        assertThat(kakaoPlace.addressName()).isEqualTo("서울 강남구 삼성동 159");
+        assertThat(kakaoPlace.roadAddressName()).isEqualTo("서울 강남구 영동대로 513");
+        assertThat(kakaoPlace.x()).isEqualTo(Double.valueOf("127.05902969025047"));
+        assertThat(kakaoPlace.y()).isEqualTo(Double.valueOf("37.51207412593136"));
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 위도, 경도 변수명 변경
- 잘못된 클래스 이름 변경
- 테스트 코드 추가

---

## 📝 코멘트
- 기존에 얘기했던 카카오와 관련된 부분에서만 x,y로 놓고 나머지 저희 쪽 로직에서는 **longitude**, **latitude**로 변경하였습니다.
- **kako**로 잘못 표기된 이름을 수정하였습니다.
- 카카오 api로 조회하는 과정에서 응답 받는 데이터를 변경하였습니다.
- 카카오가 실제로 제공해주는 총 데이터를 넘을 경우 `KakaoSearcher` 가 빈 리스트를 반환하는 테스트 로직을 추가하였습니다.
