### PR TITLE
feat: #92 혼밥 상태 조회, 수정/저장 api 개발

### DIFF
--- a/src/main/java/com/moyorak/api/auth/controller/UserDailyStateController.java
+++ b/src/main/java/com/moyorak/api/auth/controller/UserDailyStateController.java
@@ -11,7 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/me")
 @SecurityRequirement(name = "JWT")
-@Tag(name = "마이페이지 API", description = "마이페이지 API 입니다.")
+@Tag(name = "[마이] 마이페이지 API", description = "마이페이지 API 입니다.")
 public class UserDailyStateController {
 
     private final UserDailyStateService userDailyStateService;
@@ -32,7 +32,7 @@ public class UserDailyStateController {
         return userDailyStateService.getDailyState(userPrincipal.getId());
     }
 
-    @PutMapping("/meal/alone")
+    @PostMapping("/meal/alone")
     @Operation(summary = "혼밥 모드 변경(on/off)", description = "혼밥 모드를 변경 합니다(on/off).")
     public void changeMealStatus(
             @AuthenticationPrincipal final UserPrincipal userPrincipal,

--- a/src/main/java/com/moyorak/api/auth/controller/UserDailyStateController.java
+++ b/src/main/java/com/moyorak/api/auth/controller/UserDailyStateController.java
@@ -1,0 +1,42 @@
+package com.moyorak.api.auth.controller;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.auth.dto.UserDailyStateRequest;
+import com.moyorak.api.auth.dto.UserDailyStateResponse;
+import com.moyorak.api.auth.service.UserDailyStateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/me")
+@SecurityRequirement(name = "JWT")
+@Tag(name = "마이페이지 API", description = "마이페이지 API 입니다.")
+public class UserDailyStateController {
+
+    private final UserDailyStateService userDailyStateService;
+
+    @GetMapping("/meal/alone")
+    @Operation(summary = "혼밥 상태 조회", description = "혼밥 상태를 조회해 옵니다.")
+    public UserDailyStateResponse getMealStatus(
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        return userDailyStateService.getDailyState(userPrincipal.getId());
+    }
+
+    @PutMapping("/meal/alone")
+    @Operation(summary = "혼밥 모드 변경(on/off)", description = "혼밥 모드를 변경 합니다(on/off).")
+    public void changeMealStatus(
+            @AuthenticationPrincipal final UserPrincipal userPrincipal,
+            @RequestBody @Valid final UserDailyStateRequest request) {
+        userDailyStateService.updateDailyState(userPrincipal.getId(), request);
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/controller/UserDailyStateController.java
+++ b/src/main/java/com/moyorak/api/auth/controller/UserDailyStateController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/me")
 @SecurityRequirement(name = "JWT")
 @Tag(name = "[마이] 마이페이지 API", description = "마이페이지 API 입니다.")
-public class UserDailyStateController {
+class UserDailyStateController {
 
     private final UserDailyStateService userDailyStateService;
 

--- a/src/main/java/com/moyorak/api/auth/domain/State.java
+++ b/src/main/java/com/moyorak/api/auth/domain/State.java
@@ -1,0 +1,6 @@
+package com.moyorak.api.auth.domain;
+
+public enum State {
+    ON,
+    OFF
+}

--- a/src/main/java/com/moyorak/api/auth/domain/State.java
+++ b/src/main/java/com/moyorak/api/auth/domain/State.java
@@ -1,6 +1,24 @@
 package com.moyorak.api.auth.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.springframework.util.StringUtils;
+
 public enum State {
     ON,
-    OFF
+    OFF;
+
+    @JsonCreator
+    public static State from(final String input) {
+        if (!StringUtils.hasText(input)) {
+            return null;
+        }
+
+        for (State state : State.values()) {
+            if (input.equals(state.name())) {
+                return state;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/com/moyorak/api/auth/domain/State.java
+++ b/src/main/java/com/moyorak/api/auth/domain/State.java
@@ -1,24 +1,6 @@
 package com.moyorak.api.auth.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import org.springframework.util.StringUtils;
-
 public enum State {
     ON,
-    OFF;
-
-    @JsonCreator
-    public static State from(final String input) {
-        if (!StringUtils.hasText(input)) {
-            return null;
-        }
-
-        for (State state : State.values()) {
-            if (input.equals(state.name())) {
-                return state;
-            }
-        }
-
-        return null;
-    }
+    OFF
 }

--- a/src/main/java/com/moyorak/api/auth/domain/UserDailyState.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserDailyState.java
@@ -1,0 +1,60 @@
+package com.moyorak.api.auth.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "member_daily_state")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDailyState extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @NotNull
+    @Comment("회원 고유 ID")
+    @Column(name = "member_id", nullable = false, columnDefinition = "bigint")
+    private Long userId;
+
+    @NotNull
+    @Comment("혼밥 상태")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false, columnDefinition = "varchar(4)")
+    private State state;
+
+    @NotNull
+    @Comment("혼밥 상태 기준 날짜")
+    @Column(name = "record_date", nullable = false)
+    private LocalDate recordDate;
+
+    public static UserDailyState create(
+            final Long userId, final State state, final LocalDate recordDate) {
+        UserDailyState dailyState = new UserDailyState();
+
+        dailyState.userId = userId;
+        dailyState.state = state;
+        dailyState.recordDate = recordDate;
+
+        return dailyState;
+    }
+
+    public void changeState(final State state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/domain/UserDailyState.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserDailyState.java
@@ -54,7 +54,7 @@ public class UserDailyState extends AuditInformation {
         return dailyState;
     }
 
-    public void changeState(final State state) {
-        this.state = state;
+    public void toggleState() {
+        this.state = (this.state == State.ON) ? State.OFF : State.ON;
     }
 }

--- a/src/main/java/com/moyorak/api/auth/dto/UserDailyStateRequest.java
+++ b/src/main/java/com/moyorak/api/auth/dto/UserDailyStateRequest.java
@@ -1,0 +1,19 @@
+package com.moyorak.api.auth.dto;
+
+import com.moyorak.api.auth.domain.State;
+import com.moyorak.api.auth.domain.UserDailyState;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Schema(title = "[마이] 혼밥 상태 업데이트 요청 DTO")
+public record UserDailyStateRequest(
+        @NotNull @Schema(description = "회원 고유 ID", example = "1") Long userId,
+        @NotNull @Schema(description = "ON/OFF", example = "OFF") State state,
+        @NotNull @Schema(description = "혼밥 상태 기준 날짜", example = "2025-06-23")
+                LocalDate recordDate) {
+
+    public UserDailyState toUserDailyState() {
+        return UserDailyState.create(userId, state, recordDate);
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/dto/UserDailyStateRequest.java
+++ b/src/main/java/com/moyorak/api/auth/dto/UserDailyStateRequest.java
@@ -9,11 +9,9 @@ import java.time.LocalDate;
 @Schema(title = "[마이] 혼밥 상태 업데이트 요청 DTO")
 public record UserDailyStateRequest(
         @NotNull @Schema(description = "회원 고유 ID", example = "1") Long userId,
-        @NotNull @Schema(description = "ON/OFF", example = "OFF") State state,
-        @NotNull @Schema(description = "혼밥 상태 기준 날짜", example = "2025-06-23")
-                LocalDate recordDate) {
+        @NotNull @Schema(description = "ON/OFF", example = "OFF") State state) {
 
-    public UserDailyState toUserDailyState() {
+    public UserDailyState toUserDailyState(LocalDate recordDate) {
         return UserDailyState.create(userId, state, recordDate);
     }
 }

--- a/src/main/java/com/moyorak/api/auth/dto/UserDailyStateRequest.java
+++ b/src/main/java/com/moyorak/api/auth/dto/UserDailyStateRequest.java
@@ -8,10 +8,9 @@ import java.time.LocalDate;
 
 @Schema(title = "[마이] 혼밥 상태 업데이트 요청 DTO")
 public record UserDailyStateRequest(
-        @NotNull @Schema(description = "회원 고유 ID", example = "1") Long userId,
-        @NotNull @Schema(description = "ON/OFF", example = "OFF") State state) {
+        @NotNull @Schema(description = "회원 고유 ID", example = "1") Long userId) {
 
     public UserDailyState toUserDailyState(LocalDate recordDate) {
-        return UserDailyState.create(userId, state, recordDate);
+        return UserDailyState.create(userId, State.ON, recordDate);
     }
 }

--- a/src/main/java/com/moyorak/api/auth/dto/UserDailyStateResponse.java
+++ b/src/main/java/com/moyorak/api/auth/dto/UserDailyStateResponse.java
@@ -1,0 +1,13 @@
+package com.moyorak.api.auth.dto;
+
+import com.moyorak.api.auth.domain.State;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(title = "[마이] 혼밥 상태 응답 DTO")
+public record UserDailyStateResponse(
+        @NotNull @Schema(description = "ON/OFF", example = "OFF") State state) {
+    public static UserDailyStateResponse from(State state) {
+        return new UserDailyStateResponse(state);
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/repository/UserDailyStateRepository.java
+++ b/src/main/java/com/moyorak/api/auth/repository/UserDailyStateRepository.java
@@ -1,0 +1,12 @@
+package com.moyorak.api.auth.repository;
+
+import com.moyorak.api.auth.domain.UserDailyState;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDailyStateRepository extends CrudRepository<UserDailyState, Long> {
+    Optional<UserDailyState> findByUserIdAndRecordDate(Long userId, LocalDate recordDate);
+}

--- a/src/main/java/com/moyorak/api/auth/repository/UserDailyStateRepository.java
+++ b/src/main/java/com/moyorak/api/auth/repository/UserDailyStateRepository.java
@@ -4,9 +4,7 @@ import com.moyorak.api.auth.domain.UserDailyState;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserDailyStateRepository extends CrudRepository<UserDailyState, Long> {
     Optional<UserDailyState> findByUserIdAndRecordDate(Long userId, LocalDate recordDate);
 }

--- a/src/main/java/com/moyorak/api/auth/service/UserDailyStateService.java
+++ b/src/main/java/com/moyorak/api/auth/service/UserDailyStateService.java
@@ -35,7 +35,7 @@ public class UserDailyStateService {
                 .findByUserIdAndRecordDate(userId, today)
                 .ifPresentOrElse(
                         existing -> {
-                            existing.changeState(request.state());
+                            existing.toggleState();
                             userDailyStateRepository.save(existing);
                         },
                         () -> userDailyStateRepository.save(request.toUserDailyState(today)));

--- a/src/main/java/com/moyorak/api/auth/service/UserDailyStateService.java
+++ b/src/main/java/com/moyorak/api/auth/service/UserDailyStateService.java
@@ -1,0 +1,35 @@
+package com.moyorak.api.auth.service;
+
+import com.moyorak.api.auth.domain.State;
+import com.moyorak.api.auth.dto.UserDailyStateRequest;
+import com.moyorak.api.auth.dto.UserDailyStateResponse;
+import com.moyorak.api.auth.repository.UserDailyStateRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDailyStateService {
+    private final UserDailyStateRepository userDailyStateRepository;
+
+    @Transactional(readOnly = true)
+    public UserDailyStateResponse getDailyState(final Long userId) {
+        LocalDate today = LocalDate.now();
+
+        return userDailyStateRepository
+                .findByUserIdAndRecordDate(userId, today)
+                .map(state -> UserDailyStateResponse.from(state.getState()))
+                .orElseGet(() -> UserDailyStateResponse.from(State.OFF));
+    }
+
+    @Transactional
+    public void updateDailyState(Long userId, UserDailyStateRequest request) {
+        userDailyStateRepository
+                .findByUserIdAndRecordDate(userId, request.recordDate())
+                .ifPresentOrElse(
+                        existing -> existing.changeState(request.state()),
+                        () -> userDailyStateRepository.save(request.toUserDailyState()));
+    }
+}

--- a/src/test/java/com/moyorak/api/auth/domain/UserDailyStateFixture.java
+++ b/src/test/java/com/moyorak/api/auth/domain/UserDailyStateFixture.java
@@ -1,0 +1,18 @@
+package com.moyorak.api.auth.domain;
+
+import java.time.LocalDate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class UserDailyStateFixture {
+
+    public static UserDailyState fixture(
+            final Long userId, final State state, final LocalDate recordDate) {
+        UserDailyState dailyState = new UserDailyState();
+
+        ReflectionTestUtils.setField(dailyState, "id", userId);
+        ReflectionTestUtils.setField(dailyState, "state", state);
+        ReflectionTestUtils.setField(dailyState, "recordDate", recordDate);
+
+        return dailyState;
+    }
+}

--- a/src/test/java/com/moyorak/api/auth/service/UserDailyStateServiceTest.java
+++ b/src/test/java/com/moyorak/api/auth/service/UserDailyStateServiceTest.java
@@ -10,6 +10,7 @@ import com.moyorak.api.auth.domain.State;
 import com.moyorak.api.auth.domain.UserDailyState;
 import com.moyorak.api.auth.domain.UserDailyStateFixture;
 import com.moyorak.api.auth.dto.UserDailyStateRequest;
+import com.moyorak.api.auth.dto.UserDailyStateResponse;
 import com.moyorak.api.auth.repository.UserDailyStateRepository;
 import com.moyorak.config.exception.BusinessException;
 import java.time.LocalDate;
@@ -55,8 +56,11 @@ class UserDailyStateServiceTest {
             given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
                     .willReturn(Optional.empty());
 
-            // when & then
-            assertThat(userDailyStateService.getDailyState(userId).state()).isEqualTo(State.OFF);
+            // when
+            final UserDailyStateResponse response = userDailyStateService.getDailyState(userId);
+
+            // then
+            assertThat(response.state()).isEqualTo(State.OFF);
         }
     }
 
@@ -68,7 +72,7 @@ class UserDailyStateServiceTest {
         @DisplayName("요청한 유저 ID와 실제 유저 ID가 다르면 예외가 발생합니다.")
         void userIdMismatchThrowsException() {
             // given
-            final UserDailyStateRequest request = new UserDailyStateRequest(2L, State.ON);
+            final UserDailyStateRequest request = new UserDailyStateRequest(2L);
 
             // when & then
             assertThatThrownBy(() -> userDailyStateService.updateDailyState(userId, request))
@@ -81,7 +85,7 @@ class UserDailyStateServiceTest {
         void updateExistingStateAndSave() {
             // given
             final UserDailyState existing = UserDailyStateFixture.fixture(userId, State.OFF, today);
-            final UserDailyStateRequest request = new UserDailyStateRequest(userId, State.ON);
+            final UserDailyStateRequest request = new UserDailyStateRequest(userId);
 
             given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
                     .willReturn(Optional.of(existing));
@@ -98,7 +102,7 @@ class UserDailyStateServiceTest {
         @DisplayName("혼밥 상태가 없다면 새로 저장합니다.")
         void saveNewState() {
             // given
-            final UserDailyStateRequest request = new UserDailyStateRequest(userId, State.ON);
+            final UserDailyStateRequest request = new UserDailyStateRequest(userId);
 
             given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
                     .willReturn(Optional.empty());

--- a/src/test/java/com/moyorak/api/auth/service/UserDailyStateServiceTest.java
+++ b/src/test/java/com/moyorak/api/auth/service/UserDailyStateServiceTest.java
@@ -1,0 +1,113 @@
+package com.moyorak.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.moyorak.api.auth.domain.State;
+import com.moyorak.api.auth.domain.UserDailyState;
+import com.moyorak.api.auth.domain.UserDailyStateFixture;
+import com.moyorak.api.auth.dto.UserDailyStateRequest;
+import com.moyorak.api.auth.repository.UserDailyStateRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserDailyStateServiceTest {
+
+    @InjectMocks private UserDailyStateService userDailyStateService;
+
+    @Mock private UserDailyStateRepository userDailyStateRepository;
+
+    final Long userId = 1L;
+    final LocalDate today = LocalDate.now();
+
+    @Nested
+    @DisplayName("혼밥 상태 조회 시,")
+    class GetDailyState {
+
+        @Test
+        @DisplayName("저장된 혼밥 상태가 있다면 해당 상태를 반환합니다.")
+        void returnExistingState() {
+            // given
+            given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
+                    .willReturn(
+                            Optional.of(UserDailyStateFixture.fixture(userId, State.ON, today)));
+
+            // when & then
+            assertThat(userDailyStateService.getDailyState(userId).state()).isEqualTo(State.ON);
+        }
+
+        @Test
+        @DisplayName("저장된 혼밥 상태가가 없다면 OFF 상태를 반환합니다.")
+        void returnDefaultOffState() {
+            // given
+            given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThat(userDailyStateService.getDailyState(userId).state()).isEqualTo(State.OFF);
+        }
+    }
+
+    @Nested
+    @DisplayName("혼밥 상태를 변경할 때,")
+    class UpdateDailyState {
+
+        @Test
+        @DisplayName("요청한 유저 ID와 실제 유저 ID가 다르면 예외가 발생합니다.")
+        void userIdMismatchThrowsException() {
+            // given
+            final UserDailyStateRequest request = new UserDailyStateRequest(2L, State.ON);
+
+            // when & then
+            assertThatThrownBy(() -> userDailyStateService.updateDailyState(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("유저 정보가 잘못됐습니다.");
+        }
+
+        @Test
+        @DisplayName("혼밥 상태가 존재하면 상태를 업데이트하고 저장합니다.")
+        void updateExistingStateAndSave() {
+            // given
+            final UserDailyState existing = UserDailyStateFixture.fixture(userId, State.OFF, today);
+            final UserDailyStateRequest request = new UserDailyStateRequest(userId, State.ON);
+
+            given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
+                    .willReturn(Optional.of(existing));
+
+            // when
+            userDailyStateService.updateDailyState(userId, request);
+
+            // then
+            assertThat(existing.getState()).isEqualTo(State.ON);
+            then(userDailyStateRepository).should().save(existing);
+        }
+
+        @Test
+        @DisplayName("혼밥 상태가 없다면 새로 저장합니다.")
+        void saveNewState() {
+            // given
+            final UserDailyStateRequest request = new UserDailyStateRequest(userId, State.ON);
+
+            given(userDailyStateRepository.findByUserIdAndRecordDate(userId, today))
+                    .willReturn(Optional.empty());
+
+            // when
+            userDailyStateService.updateDailyState(userId, request);
+
+            // then
+            then(userDailyStateRepository).should().save(any(UserDailyState.class));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
혼바 상태를 조회, 수정/저장 하는 기능을 추가 하였습니다.

1. 혼밥 상태를 조회 시, 서버에서 오늘 날짜의 혼밥 상태가 있는지 조회를 합니다.
2. 조회 시, 저장된 혼밥 상태가 없다면, 'OFF' 값을 내려 보냅니다.
3. 혼밥 상태를 수정 할 때, 토큰 값과 유저 ID 를 비교하여 정상적인 유저 정보인지를 확인합니다.
4. 혼밥 상태를 수정 할 때, 혼밥 상태가 존재하면, 수정을 합니다.
5. 혼밥 상태를 수정 할 때, 혼밥 상태가 존재하지 않으면, 해당 상태 값으로 혼밥 상태를 저장합니다.

---

## 📝 코멘트
- 충돌을 방지하여 `UserDailyState` 이름으로 컨트롤러, 서비스를 생성하였습니다. 
