### PR TITLE
feat: #100 PresignedUrl 업로드 url 발급 받는 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,9 @@ jobs:
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
           echo "JWT_REFRESH_SECRET=${{ secrets.JWT_REFRESH_SECRET }}" >> .env
+          echo "S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}" >> .env
+          echo "S3_BUCKET_URI=${{ secrets.S3_BUCKET_URI }}" >> .env
+          echo "S3_BUCKET_DIRECTORY=${{ secrets.S3_BUCKET_DIRECTORY }}" >> .env
           echo "SPRING_PROFILES_ACTIVE=${{ github.event.inputs.springProfile }}" >> .env
 
       - name: Copy .env to EC2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,9 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          S3_BUCKET_URI: ${{ secrets.S3_BUCKET_URI }}
+          S3_BUCKET_DIRECTORY: ${{ secrets.S3_BUCKET_DIRECTORY }}
           SPRING_PROFILES_ACTIVE: dev
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,10 @@ dependencies {
 
 	// swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+
+    // AWS SDK
+    implementation(platform("software.amazon.awssdk:bom:2.31.68"))
+    implementation("software.amazon.awssdk:s3")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/moyorak/api/image/controller/ImageController.java
+++ b/src/main/java/com/moyorak/api/image/controller/ImageController.java
@@ -1,0 +1,29 @@
+package com.moyorak.api.image.controller;
+
+import com.moyorak.api.image.dto.ImageSaveRequest;
+import com.moyorak.api.image.dto.ImageSaveResponse;
+import com.moyorak.api.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[이미지] 이미지 관리 API", description = "이미지 관리를 위한 API 입니다.")
+class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    @Operation(summary = "[이미지] 이미지 저장 URL 발급", description = "이미지를 저장하기 위한 URL을 발급 받습니다.")
+    public ImageSaveResponse generate(@RequestBody final ImageSaveRequest request) {
+        return imageService.generateUrl(request);
+    }
+}

--- a/src/main/java/com/moyorak/api/image/dto/ImageSaveRequest.java
+++ b/src/main/java/com/moyorak/api/image/dto/ImageSaveRequest.java
@@ -1,0 +1,21 @@
+package com.moyorak.api.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record ImageSaveRequest(
+        @NotBlank @Schema(description = "파일 확장자명", example = "png") String extensionName) {
+
+    private static final List<String> VALID_EXTENSION_NAMES = List.of("jpg", "png", "jpeg");
+
+    @AssertTrue(message = "허용되지 않은 확장자명입니다.")
+    public boolean isInvalidExtensionName(final String extensionName) {
+        if (extensionName == null) {
+            return false;
+        }
+
+        return VALID_EXTENSION_NAMES.contains(extensionName.toLowerCase());
+    }
+}

--- a/src/main/java/com/moyorak/api/image/dto/ImageSaveResponse.java
+++ b/src/main/java/com/moyorak/api/image/dto/ImageSaveResponse.java
@@ -1,0 +1,8 @@
+package com.moyorak.api.image.dto;
+
+public record ImageSaveResponse(String url, String path) {
+
+    public static ImageSaveResponse from(final String url, final String path) {
+        return new ImageSaveResponse(url, path);
+    }
+}

--- a/src/main/java/com/moyorak/api/image/service/ImageService.java
+++ b/src/main/java/com/moyorak/api/image/service/ImageService.java
@@ -1,0 +1,25 @@
+package com.moyorak.api.image.service;
+
+import com.moyorak.api.image.dto.ImageSaveRequest;
+import com.moyorak.api.image.dto.ImageSaveResponse;
+import com.moyorak.infra.aws.s3.S3Adapter;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Adapter s3Adapter;
+
+    public ImageSaveResponse generateUrl(final ImageSaveRequest request) {
+        final String uuid = UUID.randomUUID().toString();
+        final String path =
+                s3Adapter.createFilePath(LocalDateTime.now(), uuid, request.extensionName());
+        final String url = s3Adapter.createPreSignUrl(path, request.extensionName());
+
+        return ImageSaveResponse.from(url, path);
+    }
+}

--- a/src/main/java/com/moyorak/config/exception/BusinessException.java
+++ b/src/main/java/com/moyorak/config/exception/BusinessException.java
@@ -9,4 +9,8 @@ public class BusinessException extends RuntimeException {
     public BusinessException(String message) {
         super(message);
     }
+
+    public BusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/moyorak/infra/aws/s3/S3Adapter.java
+++ b/src/main/java/com/moyorak/infra/aws/s3/S3Adapter.java
@@ -2,6 +2,8 @@ package com.moyorak.infra.aws.s3;
 
 import com.moyorak.config.exception.BusinessException;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -56,6 +58,22 @@ public class S3Adapter {
         } catch (RuntimeException e) {
             throw new BusinessException("PrisignedUrl 생성에 실패하였습니다.", e);
         }
+    }
+
+    /**
+     * 파일이 저장 될 path를 생성합니다.
+     *
+     * @param now 파일명의 중복을 최소화 하기 위한 장치
+     * @param extensionName 확장자명
+     * @return path
+     */
+    public String createFilePath(
+            final LocalDateTime now, final String uuid, final String extensionName) {
+        final String date = now.format(DateTimeFormatter.BASIC_ISO_DATE);
+        final String time = now.format(DateTimeFormatter.ofPattern("HH_mm_ss"));
+
+        return String.format(
+                "%s%s/%s-%s.%s", s3Properties.getDirectory(), date, uuid, time, extensionName);
     }
 
     /** 입력값의 유효성 검증을 합니다. null, 빈 문자열(''), 공백 문자열(' ')의 경우 false를 반환합니다. */

--- a/src/main/java/com/moyorak/infra/aws/s3/S3Adapter.java
+++ b/src/main/java/com/moyorak/infra/aws/s3/S3Adapter.java
@@ -1,0 +1,65 @@
+package com.moyorak.infra.aws.s3;
+
+import com.moyorak.config.exception.BusinessException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Adapter {
+
+    public static final Duration IMAGE_URL_EXPIRATION = Duration.ofMinutes(3);
+
+    private final S3Presigner s3Presigner;
+    private final S3Properties s3Properties;
+
+    /**
+     * S3를 이용하여 이미지 업로드를 위한 Presigned URL을 생성합니다. URL의 유효시간은 3분입니다.
+     *
+     * @param path S3에 저장될 파일의 경로
+     * @param extensionName 파일의 확장자 이름 (예: "jpg", "png")
+     * @return Presigned URL
+     */
+    public String createPreSignUrl(final String path, final String extensionName) {
+        if (isValidName(path)) {
+            throw new BusinessException("path 값이 유효하지 않습니다.");
+        }
+
+        final String contentType = String.format("image/%s", extensionName);
+
+        PutObjectRequest request =
+                PutObjectRequest.builder()
+                        .bucket(s3Properties.getBucketName())
+                        .key(path)
+                        .contentType(contentType)
+                        .build();
+
+        PutObjectPresignRequest putObjectPresignRequest =
+                PutObjectPresignRequest.builder()
+                        .signatureDuration(IMAGE_URL_EXPIRATION)
+                        .putObjectRequest(request)
+                        .build();
+
+        try {
+            PresignedPutObjectRequest presignedPutObjectRequest =
+                    s3Presigner.presignPutObject(putObjectPresignRequest);
+
+            return presignedPutObjectRequest.url().toExternalForm();
+        } catch (RuntimeException e) {
+            throw new BusinessException("PrisignedUrl 생성에 실패하였습니다.", e);
+        }
+    }
+
+    /** 입력값의 유효성 검증을 합니다. null, 빈 문자열(''), 공백 문자열(' ')의 경우 false를 반환합니다. */
+    private boolean isValidName(final String value) {
+        return value == null || ObjectUtils.isEmpty(value.trim());
+    }
+}

--- a/src/main/java/com/moyorak/infra/aws/s3/S3Config.java
+++ b/src/main/java/com/moyorak/infra/aws/s3/S3Config.java
@@ -1,0 +1,15 @@
+package com.moyorak.infra.aws.s3;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+class S3Config {
+
+    @Bean
+    public S3Presigner s3PresignerConfig() {
+        return S3Presigner.builder().region(Region.AP_NORTHEAST_2).build();
+    }
+}

--- a/src/main/java/com/moyorak/infra/aws/s3/S3Properties.java
+++ b/src/main/java/com/moyorak/infra/aws/s3/S3Properties.java
@@ -1,0 +1,25 @@
+package com.moyorak.infra.aws.s3;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+class S3Properties {
+
+    private final String bucketName;
+
+    private final String uri;
+
+    private final String directory;
+
+    S3Properties(
+            @Value("${aws.s3.bucket}") final String bucketName,
+            @Value("${aws.s3.uri}") final String uri,
+            @Value("${aws.s3.directory}") final String directory) {
+        this.bucketName = bucketName;
+        this.uri = uri;
+        this.directory = directory;
+    }
+}

--- a/src/main/resources/application-local-tepmlate.yml
+++ b/src/main/resources/application-local-tepmlate.yml
@@ -17,3 +17,9 @@ jwt:
   expiration: 900000
   refresh-secret: jwt-refresh-secret
   refresh-expiration: 604800000
+
+aws:
+  s3:
+    bucket: bucket-name
+    uri: bucket-uri
+    directory: bucket-directory

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,9 @@ spring:
 
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
+
+aws:
+  s3:
+    bucket: ${S3_BUCKET_NAME}
+    uri: ${S3_BUCKET_URI}
+    directory: ${S3_BUCKET_DIRECTORY}

--- a/src/test/java/com/moyorak/api/image/dto/ImageSaveRequestTest.java
+++ b/src/test/java/com/moyorak/api/image/dto/ImageSaveRequestTest.java
@@ -1,0 +1,46 @@
+package com.moyorak.api.image.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ImageSaveRequestTest {
+
+    @Nested
+    @DisplayName("유효한 확장명인지 확인할 때,")
+    class isInvalidExtensionName {
+
+        @ParameterizedTest
+        @ValueSource(strings = {" ", "gif"})
+        @NullAndEmptySource
+        @DisplayName("유효한 확장명이 아니면, false를 반환합니다.")
+        void isFalse(final String input) {
+            // given
+            final ImageSaveRequest request = new ImageSaveRequest(input);
+
+            // when
+            final boolean result = request.isInvalidExtensionName(input);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"jpg", "jpeg", "png"})
+        @DisplayName("유효한 확장명이면 true를 반환합니다.")
+        void isTrue(final String input) {
+            // given
+            final ImageSaveRequest request = new ImageSaveRequest(input);
+
+            // when
+            final boolean result = request.isInvalidExtensionName(input);
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/moyorak/infra/aws/s3/S3AdapterTest.java
+++ b/src/test/java/com/moyorak/infra/aws/s3/S3AdapterTest.java
@@ -1,0 +1,40 @@
+package com.moyorak.infra.aws.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+class S3AdapterTest {
+
+    private final S3Properties s3Properties =
+            new S3Properties("moyorak", "http://localhost/", "stg/");
+
+    private final S3Adapter s3Adapter = new S3Adapter(mock(S3Presigner.class), s3Properties);
+
+    @Nested
+    @DisplayName("path 생성할 때,")
+    class createFilePath {
+
+        @Test
+        @DisplayName("성공적으로 생성합니다.")
+        void success() {
+            // given
+            final LocalDateTime now = LocalDateTime.of(2025, 6, 25, 11, 0, 0);
+            final String extensionName = "jpg";
+            final String uuid = "UUID";
+
+            final String expectedResult = "stg/20250625/UUID-11_00_00.jpg";
+
+            // when
+            final String result = s3Adapter.createFilePath(now, uuid, extensionName);
+
+            // then
+            assertThat(result).isEqualTo(expectedResult);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
업로드 하고자하는 파일의 확장명을 입력하면 사전 인증이 완료 되어 업로드 가능한 URL을 발급 받습니다.
내부적으로 저장을 위한 path 값과 함께 응답을 내려줄 수 있는 기능을 추가하였습니다.

해당 기능이 머지되면 `application-local.yml`을 추가해주세요.
노션에 해당 항목 추가 해 두었습니다.

유효한 확장명은 `jpg` `png` `jpeg` 입니다.

---

## 📝 코멘트
- S3 SDK dependency 추가
- S3Properties 추가
- S3 버킷에 이미지 업로드를 위한 PresignedURL 발급 기능 추가