### PR TITLE
fix: #113 토큰 발급 endpoint 시큐리티 필터에서 처리되지 않도록 조건 추가

### DIFF
--- a/src/main/java/com/moyorak/config/security/SecurityConfig.java
+++ b/src/main/java/com/moyorak/config/security/SecurityConfig.java
@@ -39,7 +39,8 @@ class SecurityConfig {
                                                 "/swagger-ui/**",
                                                 "/v3/api-docs/**",
                                                 "/api/auth/refresh",
-                                                "/api/user/sign-up")
+                                                "/api/user/sign-up",
+                                                "/api/auth/sign-in")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())


### PR DESCRIPTION
## 📌 주요 변경 사항
- 토큰 발급을 위한 endpoint의 경우 토큰이 불필요한데, 시큐리티 필터에 걸리는 문제로 제거 되기 위해 조건을 추가하였습니다.

---

## 📝 코멘트
- `SecurityConfig` endpoint 추가