### PR TITLE
feat: #101 이미지 조회를 위한 PresignedURL 생성 기능 추가

### DIFF
--- a/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlListRequest.java
+++ b/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlListRequest.java
@@ -1,0 +1,19 @@
+package com.moyorak.api.image.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(title = "[이미지] 이미지 조회 리스트 요청 DTO")
+public record ImagePresignedUrlListRequest(
+        @NotNull
+                @Size(min = 1, max = 10)
+                @ArraySchema(
+                        schema =
+                                @Schema(
+                                        description = "파일 조회 path 리스트",
+                                        implementation = ImagePresignedUrlRequest.class),
+                        arraySchema = @Schema(description = "Presigned URL 요청 리스트"))
+                List<ImagePresignedUrlRequest> paths) {}

--- a/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlListResponse.java
+++ b/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlListResponse.java
@@ -1,0 +1,20 @@
+package com.moyorak.api.image.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(title = "[이미지] 이미지 조회 리스트 응답 DTO")
+public record ImagePresignedUrlListResponse(
+        @ArraySchema(
+                        schema =
+                                @Schema(
+                                        description = "이미지 url 리스트",
+                                        implementation = ImagePresignedUrlResponse.class),
+                        arraySchema = @Schema(description = "Presigned URL 응답 리스트"))
+                List<ImagePresignedUrlResponse> urls) {
+
+    public static ImagePresignedUrlListResponse from(final List<ImagePresignedUrlResponse> urls) {
+        return new ImagePresignedUrlListResponse(urls);
+    }
+}

--- a/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlRequest.java
+++ b/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlRequest.java
@@ -1,0 +1,12 @@
+package com.moyorak.api.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(title = "[이미지] 이미지 조회 요청 DTO")
+public record ImagePresignedUrlRequest(
+        @NotBlank
+                @Schema(
+                        description = "파일 조회 path",
+                        example = "dev/20250630/ca811057-a488-42bf-96b4-290c2fc5a8ef-20_41_27.png")
+                String path) {}

--- a/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlResponse.java
+++ b/src/main/java/com/moyorak/api/image/dto/ImagePresignedUrlResponse.java
@@ -1,0 +1,12 @@
+package com.moyorak.api.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[이미지] 이미지 조회 응답 DTO")
+public record ImagePresignedUrlResponse(
+        @Schema(description = "이미지 Presigned URL", example = "https://...") String url) {
+
+    public static ImagePresignedUrlResponse from(final String url) {
+        return new ImagePresignedUrlResponse(url);
+    }
+}

--- a/src/main/java/com/moyorak/api/image/service/ImageService.java
+++ b/src/main/java/com/moyorak/api/image/service/ImageService.java
@@ -1,12 +1,17 @@
 package com.moyorak.api.image.service;
 
 import com.moyorak.api.image.dto.ImageDeleteRequest;
+import com.moyorak.api.image.dto.ImagePresignedUrlListRequest;
+import com.moyorak.api.image.dto.ImagePresignedUrlListResponse;
+import com.moyorak.api.image.dto.ImagePresignedUrlRequest;
+import com.moyorak.api.image.dto.ImagePresignedUrlResponse;
 import com.moyorak.api.image.dto.ImageSaveRequest;
 import com.moyorak.api.image.dto.ImageSaveResponse;
 import com.moyorak.config.exception.BusinessException;
 import com.moyorak.infra.aws.s3.S3Adapter;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,5 +36,16 @@ public class ImageService {
         }
 
         s3Adapter.delete(request.path());
+    }
+
+    public ImagePresignedUrlResponse getUrl(final ImagePresignedUrlRequest request) {
+        final String url = s3Adapter.getPresignedUrl(request.path());
+
+        return ImagePresignedUrlResponse.from(url);
+    }
+
+    public ImagePresignedUrlListResponse getUrls(final ImagePresignedUrlListRequest requests) {
+        return ImagePresignedUrlListResponse.from(
+                requests.paths().stream().map(this::getUrl).collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
이미지 조회를 위한 PresignedURL 생성 기능을 추가 하였습니다.
유효 시간은 30초입니다.

해당 기능은 특정 기능에서 조회를 할 때, 저장 된 이미지 path를 이용해 생성하고
이를 응답에 내려주시면 될 것 같습니다.
---

## 📝 코멘트
- 이미지 조회를 위한 PresignedURL 생성 기능 추가
