### PR TITLE
feat: #128 팀 ID 혹은 이름을 통해 팀 정보 조회할 수 있는 API 추가

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamController.java
@@ -5,6 +5,7 @@ import com.moyorak.api.team.dto.TeamSearchRequest;
 import com.moyorak.api.team.service.TeamService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -25,7 +26,7 @@ class TeamController {
 
     @GetMapping("/api/companies/{companyId}")
     public TeamSearchListResponse searchTeamsInfo(
-            @PathVariable @Positive final Long companyId, final TeamSearchRequest request) {
+            @PathVariable @Positive final Long companyId, @Valid final TeamSearchRequest request) {
         return teamService.search(companyId, request);
     }
 }

--- a/src/main/java/com/moyorak/api/team/controller/TeamController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamController.java
@@ -24,7 +24,7 @@ class TeamController {
 
     private final TeamService teamService;
 
-    @GetMapping("/api/companies/{companyId}")
+    @GetMapping("/companies/{companyId}")
     public TeamSearchListResponse searchTeamsInfo(
             @PathVariable @Positive final Long companyId, @Valid final TeamSearchRequest request) {
         return teamService.search(companyId, request);

--- a/src/main/java/com/moyorak/api/team/controller/TeamController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamController.java
@@ -1,0 +1,31 @@
+package com.moyorak.api.team.controller;
+
+import com.moyorak.api.team.dto.TeamSearchListResponse;
+import com.moyorak.api.team.dto.TeamSearchRequest;
+import com.moyorak.api.team.service.TeamService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[회사] [팀] 팀 관리 API", description = "팀 관리를 위한 API 입니다.")
+class TeamController {
+
+    private final TeamService teamService;
+
+    @GetMapping("/api/companies/{companyId}")
+    public TeamSearchListResponse searchTeamsInfo(
+            @PathVariable @Positive final Long companyId, final TeamSearchRequest request) {
+        return teamService.search(companyId, request);
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/TeamSearch.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamSearch.java
@@ -1,0 +1,41 @@
+package com.moyorak.api.team.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import com.moyorak.infra.orm.BooleanYnConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "team")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamSearch extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Comment("회사 고유 ID")
+    @Column(name = "company_id", nullable = false)
+    private Long companyId;
+
+    @Comment("팀 이름")
+    @Column(name = "name", nullable = false, columnDefinition = "varchar(255)")
+    private String name;
+
+    @Comment("사용 여부")
+    @Convert(converter = BooleanYnConverter.class)
+    @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
+    private boolean use = true;
+}

--- a/src/main/java/com/moyorak/api/team/dto/TeamSearchListResponse.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamSearchListResponse.java
@@ -1,0 +1,24 @@
+package com.moyorak.api.team.dto;
+
+import com.moyorak.api.team.domain.TeamSearch;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springdoc.core.annotations.ParameterObject;
+
+@ParameterObject
+@Schema(title = "팀 이름 검색 응답 DTO")
+public record TeamSearchListResponse(
+        @ArraySchema(
+                        schema =
+                                @Schema(
+                                        description = "팀 정보",
+                                        implementation = TeamSearchResponse.class),
+                        arraySchema = @Schema(description = "팀 정보 검색 응답 리스트"))
+                List<TeamSearchResponse> teams) {
+    public static TeamSearchListResponse from(final List<TeamSearch> entities) {
+        return new TeamSearchListResponse(
+                entities.stream().map(TeamSearchResponse::from).collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/moyorak/api/team/dto/TeamSearchRequest.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamSearchRequest.java
@@ -1,10 +1,17 @@
 package com.moyorak.api.team.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import org.springdoc.core.annotations.ParameterObject;
 
 @ParameterObject
 @Schema(title = "팀 이름 검색 요청 DTO")
 public record TeamSearchRequest(
         @Schema(description = "팀 고유 ID", example = "21") Long teamId,
-        @Schema(description = "팀 이름", example = "Backend") String name) {}
+        @Schema(description = "팀 이름", example = "Backend") String name) {
+
+    @AssertTrue(message = "팀 ID와 팀 이름 중 최소 하나는 필수입니다.")
+    public boolean hasAtLeastOneCondition() {
+        return teamId != null || (name != null && !name.trim().isEmpty());
+    }
+}

--- a/src/main/java/com/moyorak/api/team/dto/TeamSearchRequest.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamSearchRequest.java
@@ -1,0 +1,10 @@
+package com.moyorak.api.team.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
+
+@ParameterObject
+@Schema(title = "팀 이름 검색 요청 DTO")
+public record TeamSearchRequest(
+        @Schema(description = "팀 고유 ID", example = "21") Long teamId,
+        @Schema(description = "팀 이름", example = "Backend") String name) {}

--- a/src/main/java/com/moyorak/api/team/dto/TeamSearchResponse.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamSearchResponse.java
@@ -1,0 +1,16 @@
+package com.moyorak.api.team.dto;
+
+import com.moyorak.api.team.domain.TeamSearch;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
+
+@ParameterObject
+@Schema(title = "팀 이름 검색 응답 DTO")
+public record TeamSearchResponse(
+        @Schema(description = "팀 고유 ID", example = "21") Long teamId,
+        @Schema(description = "팀 이름", example = "Backend파트") String name) {
+
+    public static TeamSearchResponse from(final TeamSearch team) {
+        return new TeamSearchResponse(team.getId(), team.getName());
+    }
+}

--- a/src/main/java/com/moyorak/api/team/repository/TeamRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamRepository.java
@@ -1,0 +1,33 @@
+package com.moyorak.api.team.repository;
+
+import com.moyorak.api.team.domain.TeamSearch;
+import jakarta.persistence.QueryHint;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface TeamRepository extends CrudRepository<TeamSearch, Long> {
+
+    @Query(
+            value =
+                    """
+            SELECT t
+            FROM TeamSearch t
+            WHERE (:companyId IS NULL OR t.companyId = :companyId)
+            AND (:teamId IS NULL OR t.id = :teamId)
+            AND (:name IS NULL OR t.name LIKE CONCAT('%', :name, '%'))
+            AND t.use = true
+            ORDER BY t.id ASC
+            LIMIT 5
+        """)
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamRepository.findByConditions : 팀 정보를 검색합니다."))
+    List<TeamSearch> findByConditions(
+            @Param("companyId") Long companyId,
+            @Param("teamId") Long teamId,
+            @Param("name") String name);
+}

--- a/src/main/java/com/moyorak/api/team/service/TeamService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamService.java
@@ -1,0 +1,25 @@
+package com.moyorak.api.team.service;
+
+import com.moyorak.api.team.domain.TeamSearch;
+import com.moyorak.api.team.dto.TeamSearchListResponse;
+import com.moyorak.api.team.dto.TeamSearchRequest;
+import com.moyorak.api.team.repository.TeamRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    @Transactional(readOnly = true)
+    public TeamSearchListResponse search(final Long companyId, final TeamSearchRequest request) {
+        final List<TeamSearch> teams =
+                teamRepository.findByConditions(companyId, request.teamId(), request.name());
+
+        return TeamSearchListResponse.from(teams);
+    }
+}

--- a/src/test/java/com/moyorak/api/team/dto/TeamSearchRequestTest.java
+++ b/src/test/java/com/moyorak/api/team/dto/TeamSearchRequestTest.java
@@ -1,0 +1,56 @@
+package com.moyorak.api.team.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TeamSearchRequestTest {
+
+    @Nested
+    @DisplayName("입력 값이 최소 하나는 필수인 것을 검증할 때,")
+    class hasAtLeastOneCondition {
+
+        @Test
+        @DisplayName("입력 값 모두 null이면 false를 반환한다.")
+        void isNull() {
+            // given
+            final TeamSearchRequest request = new TeamSearchRequest(null, null);
+
+            // when
+            final boolean result = request.hasAtLeastOneCondition();
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("팀 고유 ID만 존재하여도 true를 반환한다.")
+        void isIdNotNull() {
+            // given
+            final Long teamId = 1L;
+            final TeamSearchRequest request = new TeamSearchRequest(teamId, null);
+
+            // when
+            final boolean result = request.hasAtLeastOneCondition();
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("팀 이름만 존재하여도 true를 반환한다.")
+        void isIdNameNull() {
+            // given
+            final String name = "Backend";
+            final TeamSearchRequest request = new TeamSearchRequest(null, name);
+
+            // when
+            final boolean result = request.hasAtLeastOneCondition();
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
-팀 ID 혹은 이름을 통해 팀 리스트를 조회합니다.
엔티티는 검색 전용 엔티티를 별도로 생성하였습니다.

팀 ID 혹은 이름이 없는 경우 유효성 검증이 실패하게 됩니다.

팀 정보는 최대 5개만 보이게 됩니다.

---

## 📝 코멘트
- 검색 전용 Team 엔티티 생성
- 팀 ID 혹은 이름을 받아 검색하도록 기능 추가
- 팀 ID 혹은 이름 모두 NULL이면 유효성 검증 실패하는 조건 추가
