### PR TITLE
feat: #141 초대 링크 생성

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
@@ -1,0 +1,35 @@
+package com.moyorak.api.team.controller;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.team.dto.TeamInvitationCreateResponse;
+import com.moyorak.api.team.service.TeamInvitationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[팀 초대] 팀 초대 API", description = "팀 초대를 위한 API 입니다.")
+class TeamInvitationController {
+
+    private final TeamInvitationService teamInvitationService;
+
+    @PostMapping("/teams/{teamId}/invitation")
+    @Operation(summary = "팀 초대 링크 생성", description = "팀 초대를 위한 링크를 생성합니다.")
+    public TeamInvitationCreateResponse createTeamInvitation(
+            @PathVariable @Positive final Long teamId,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        return teamInvitationService.createTeamInvitation(teamId, userPrincipal.getId());
+    }
+}

--- a/src/main/java/com/moyorak/api/team/controller/TeamRestaurantController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamRestaurantController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/teams")

--- a/src/main/java/com/moyorak/api/team/domain/InvitationToken.java
+++ b/src/main/java/com/moyorak/api/team/domain/InvitationToken.java
@@ -1,0 +1,15 @@
+package com.moyorak.api.team.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record InvitationToken(String token, LocalDateTime expiresDate) {
+    private static final int INVITATION_VALIDITY_SECONDS = 60 * 60 * 24; // 일단 하루 (추후에 정하기)
+
+    public static InvitationToken generate() {
+        final String token = UUID.randomUUID().toString();
+        final LocalDateTime expiresDate =
+                LocalDateTime.now().plusSeconds(INVITATION_VALIDITY_SECONDS);
+        return new InvitationToken(token, expiresDate);
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/TeamInvitation.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamInvitation.java
@@ -1,0 +1,52 @@
+package com.moyorak.api.team.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "team_invitation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamInvitation extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("팀 초대 고유 토큰")
+    @Column(
+            name = "invitation_token",
+            nullable = false,
+            unique = true,
+            columnDefinition = "varchar(64)")
+    private String invitationToken;
+
+    @Comment("토큰 만료 일자")
+    @Column(name = "expires_date", nullable = false)
+    private LocalDateTime expiresDate;
+
+    @Comment("팀 고유 ID")
+    @Column(name = "team_id", nullable = false, columnDefinition = "bigint")
+    private Long teamId;
+
+    public static TeamInvitation create(
+            String invitationToken, LocalDateTime expiresDate, Long teamId) {
+        TeamInvitation teamInvitation = new TeamInvitation();
+
+        teamInvitation.invitationToken = invitationToken;
+        teamInvitation.expiresDate = expiresDate;
+        teamInvitation.teamId = teamId;
+
+        return teamInvitation;
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/TeamUserNotFoundException.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamUserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.team.domain;
+
+import com.moyorak.config.exception.BusinessException;
+
+public class TeamUserNotFoundException extends BusinessException {
+    public TeamUserNotFoundException() {
+        super("팀 멤버가 아닙니다.");
+    }
+}

--- a/src/main/java/com/moyorak/api/team/dto/TeamInvitationCreateResponse.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamInvitationCreateResponse.java
@@ -1,0 +1,12 @@
+package com.moyorak.api.team.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[팀 초대] 팀 초대 링크 생성 응답 DTO")
+public record TeamInvitationCreateResponse(
+        @Schema(description = "팀 초대 링크 URL 주소", example = "http://moyorak/invitation/abcdefg-asddf")
+                String invitationUrl) {
+    public static TeamInvitationCreateResponse of(String invitationUrl) {
+        return new TeamInvitationCreateResponse(invitationUrl);
+    }
+}

--- a/src/main/java/com/moyorak/api/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamInvitationRepository.java
@@ -1,0 +1,6 @@
+package com.moyorak.api.team.repository;
+
+import com.moyorak.api.team.domain.TeamInvitation;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TeamInvitationRepository extends CrudRepository<TeamInvitation, Long> {}

--- a/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
@@ -20,4 +20,14 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 """)
     Optional<TeamUser> findWithTeamAndCompany(
             @Param("teamId") Long teamId, @Param("userId") Long userId, @Param("use") boolean use);
+
+    @Query(
+            """
+        SELECT tu
+        FROM TeamUser tu
+        JOIN Team t ON tu.team.id = t.id
+        WHERE tu.userId = :userId AND tu.team.id = :teamId AND tu.use = :use
+""")
+    Optional<TeamUser> findByUserIdAndTeamIdAndUse(
+            @Param("userId") Long userId, @Param("teamId") Long teamId, @Param("use") boolean use);
 }

--- a/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
@@ -1,9 +1,11 @@
 package com.moyorak.api.team.repository;
 
 import com.moyorak.api.team.domain.TeamUser;
+import jakarta.persistence.QueryHint;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
@@ -28,6 +30,10 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
         JOIN Team t ON tu.team.id = t.id
         WHERE tu.userId = :userId AND tu.team.id = :teamId AND tu.use = :use
 """)
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamUserRepository.findByUserIdAndTeamIdAndUse : 팀 멤버를 조회합니다."))
     Optional<TeamUser> findByUserIdAndTeamIdAndUse(
             @Param("userId") Long userId, @Param("teamId") Long teamId, @Param("use") boolean use);
 }

--- a/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
@@ -1,13 +1,12 @@
 package com.moyorak.api.team.service;
 
+import com.moyorak.api.team.domain.InvitationToken;
 import com.moyorak.api.team.domain.TeamInvitation;
 import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.dto.TeamInvitationCreateResponse;
 import com.moyorak.api.team.repository.TeamInvitationRepository;
 import com.moyorak.api.team.repository.TeamUserRepository;
-import java.time.LocalDateTime;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,6 @@ public class TeamInvitationService {
 
     private final TeamInvitationRepository teamInvitationRepository;
     private final TeamUserRepository teamUserRepository;
-    private static final int INVITATION_VALIDITY_SECONDS = 60 * 60 * 24; // 일단 하루 (추후에 정하기)
 
     // TODO 프론트에서 사용할 URL로 교체해야함 OR 그냥 토큰만 내려주기(프론트에서 전체 링크 생성)
     private static final String INVITATION_URL_PREFIX = "http://moyorak/invitation/";
@@ -36,12 +34,11 @@ public class TeamInvitationService {
         }
 
         // 초대 토큰 생성
-        final String invitationToken = UUID.randomUUID().toString();
-        final LocalDateTime expiresDate =
-                LocalDateTime.now().plusSeconds(INVITATION_VALIDITY_SECONDS);
+        InvitationToken invitationToken = InvitationToken.generate();
 
         final TeamInvitation teamInvitation =
-                TeamInvitation.create(invitationToken, expiresDate, teamId);
+                TeamInvitation.create(
+                        invitationToken.token(), invitationToken.expiresDate(), teamId);
         teamInvitationRepository.save(teamInvitation);
 
         final String invitationUrl = INVITATION_URL_PREFIX + teamInvitation.getInvitationToken();

--- a/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
@@ -1,0 +1,50 @@
+package com.moyorak.api.team.service;
+
+import com.moyorak.api.team.domain.TeamInvitation;
+import com.moyorak.api.team.domain.TeamUser;
+import com.moyorak.api.team.domain.TeamUserNotFoundException;
+import com.moyorak.api.team.dto.TeamInvitationCreateResponse;
+import com.moyorak.api.team.repository.TeamInvitationRepository;
+import com.moyorak.api.team.repository.TeamUserRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamInvitationService {
+
+    private final TeamInvitationRepository teamInvitationRepository;
+    private final TeamUserRepository teamUserRepository;
+    private static final int INVITATION_VALIDITY_SECONDS = 60 * 60 * 24; // 일단 하루 (추후에 정하기)
+
+    // TODO 프론트에서 사용할 URL로 교체해야함 OR 그냥 토큰만 내려주기(프론트에서 전체 링크 생성)
+    private static final String INVITATION_URL_PREFIX = "http://moyorak/invitation/";
+
+    @Transactional
+    public TeamInvitationCreateResponse createTeamInvitation(final Long teamId, final Long userId) {
+
+        // 팀원인지 체크
+        final TeamUser teamUser =
+                teamUserRepository
+                        .findByUserIdAndTeamIdAndUse(teamId, userId, true)
+                        .orElseThrow(TeamUserNotFoundException::new);
+        if (teamUser.isNotApproved()) {
+            throw new TeamUserNotFoundException();
+        }
+
+        // 초대 토큰 생성
+        final String invitationToken = UUID.randomUUID().toString();
+        final LocalDateTime expiresDate =
+                LocalDateTime.now().plusSeconds(INVITATION_VALIDITY_SECONDS);
+
+        final TeamInvitation teamInvitation =
+                TeamInvitation.create(invitationToken, expiresDate, teamId);
+        teamInvitationRepository.save(teamInvitation);
+
+        final String invitationUrl = INVITATION_URL_PREFIX + teamInvitation.getInvitationToken();
+        return TeamInvitationCreateResponse.of(invitationUrl);
+    }
+}

--- a/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
@@ -1,0 +1,66 @@
+package com.moyorak.api.team.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.api.team.domain.Team;
+import com.moyorak.api.team.domain.TeamFixture;
+import com.moyorak.api.team.domain.TeamUser;
+import com.moyorak.api.team.domain.TeamUserFixture;
+import com.moyorak.api.team.domain.TeamUserNotFoundException;
+import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.repository.TeamUserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TeamInvitationServiceTest {
+
+    @InjectMocks private TeamInvitationService teamInvitationService;
+
+    @Mock private TeamUserRepository teamUserRepository;
+
+    @Nested
+    @DisplayName("초대 링크 생성 시")
+    class Create {
+
+        final Long teamId = 1L;
+        final Long userId = 1L;
+
+        @Test
+        @DisplayName("팀 멤버가 아닌 경우 TeamUserNotFoundException이 발생한다.")
+        void noTeamUser() {
+            // given
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(teamId, userId, true))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> teamInvitationService.createTeamInvitation(teamId, userId))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("팀 멤버 상태가 APPROVED가 아닌 경우 예외가 발생한다.")
+        void isNotApproved() {
+            // given
+            final Team team = TeamFixture.fixture(teamId, null, true);
+            final TeamUser pendingTeamUser =
+                    TeamUserFixture.fixture(userId, team, TeamUserStatus.PENDING, true);
+
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(teamId, userId, true))
+                    .willReturn(Optional.of(pendingTeamUser));
+
+            // when & then
+            assertThatThrownBy(() -> teamInvitationService.createTeamInvitation(teamId, userId))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 초대 링크 생성 기능 개발

---

## 📝 코멘트
- 초대 링크 생성 기능을 개발했습니다.
개발 중에 든 생각이 어차피 프론트 단에서 사용할 url을 백엔드에서 내려줘야하는데, 백엔드에서는 그냥 UUID를 내려주고
링크 생성을 프론트에서 책임지는 것도 괜찮겠다고 생각이 들었습니다. 요건 다음 회의때 한번 고려해보면 좋을 것  같습니다.
- 일단 토큰 유효시간을 하루로 설정하였습니다.