### PR TITLE
fear: #143 초대 링크를 통해 팀 회사 정보 조회하기

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
@@ -2,6 +2,7 @@ package com.moyorak.api.team.controller;
 
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.team.dto.TeamInvitationCreateResponse;
+import com.moyorak.api.team.dto.TeamInvitationDetailResponse;
 import com.moyorak.api.team.service.TeamInvitationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -10,6 +11,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +33,11 @@ class TeamInvitationController {
             @PathVariable @Positive final Long teamId,
             @AuthenticationPrincipal final UserPrincipal userPrincipal) {
         return teamInvitationService.createTeamInvitation(teamId, userPrincipal.getId());
+    }
+
+    @GetMapping("/teams/{teamId}/invitation/{token}")
+    @Operation(summary = "팀 초대 링크 조회", description = "팀 초대를 위한 링크를 조회하고 검증합니다.")
+    public TeamInvitationDetailResponse getTeamInvitation(@PathVariable final String token) {
+        return teamInvitationService.getInvitationDetail(token);
     }
 }

--- a/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
@@ -37,7 +37,8 @@ class TeamInvitationController {
 
     @GetMapping("/teams/{teamId}/invitation/{token}")
     @Operation(summary = "팀 초대 링크 조회", description = "팀 초대를 위한 링크를 조회하고 검증합니다.")
-    public TeamInvitationDetailResponse getTeamInvitation(@PathVariable final String token) {
-        return teamInvitationService.getInvitationDetail(token);
+    public TeamInvitationDetailResponse getTeamInvitation(
+            @PathVariable @Positive final Long teamId, @PathVariable final String token) {
+        return teamInvitationService.getInvitationDetail(teamId, token);
     }
 }

--- a/src/main/java/com/moyorak/api/team/domain/TeamInvitation.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamInvitation.java
@@ -49,4 +49,8 @@ public class TeamInvitation extends AuditInformation {
 
         return teamInvitation;
     }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresDate.isBefore(now);
+    }
 }

--- a/src/main/java/com/moyorak/api/team/domain/TeamInvitation.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamInvitation.java
@@ -53,4 +53,8 @@ public class TeamInvitation extends AuditInformation {
     public boolean isExpired(LocalDateTime now) {
         return expiresDate.isBefore(now);
     }
+
+    public boolean isNotInTeam(Long teamId) {
+        return !this.teamId.equals(teamId);
+    }
 }

--- a/src/main/java/com/moyorak/api/team/domain/TeamInvitationTokenNotFoundException.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamInvitationTokenNotFoundException.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.team.domain;
+
+import com.moyorak.config.exception.BusinessException;
+
+public class TeamInvitationTokenNotFoundException extends BusinessException {
+    public TeamInvitationTokenNotFoundException() {
+        super("토큰이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/moyorak/api/team/dto/TeamInvitationDetailResponse.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamInvitationDetailResponse.java
@@ -1,0 +1,10 @@
+package com.moyorak.api.team.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[팀 초대] 팀 초대 링크 조회 응답 DTO")
+public record TeamInvitationDetailResponse(
+        @Schema(description = "회사 고유 ID", example = "1") Long companyId,
+        @Schema(description = "회사 이름", example = "(주) 우가우가") String companyName,
+        @Schema(description = "팀 고유 ID", example = "2") Long teamId,
+        @Schema(description = "팀 이름", example = "차차차본부") String teamName) {}

--- a/src/main/java/com/moyorak/api/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamInvitationRepository.java
@@ -1,6 +1,30 @@
 package com.moyorak.api.team.repository;
 
 import com.moyorak.api.team.domain.TeamInvitation;
+import com.moyorak.api.team.dto.TeamInvitationDetailResponse;
+import jakarta.persistence.QueryHint;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
-public interface TeamInvitationRepository extends CrudRepository<TeamInvitation, Long> {}
+public interface TeamInvitationRepository extends CrudRepository<TeamInvitation, Long> {
+
+    Optional<TeamInvitation> findByInvitationToken(String invitationToken);
+
+    @Query(
+            """
+SELECT new com.moyorak.api.team.dto.TeamInvitationDetailResponse(c.id, c.name, t.id, t.name)
+FROM Team t
+JOIN Company c ON t.company.id = c.id
+WHERE t.id = :teamId AND t.use = :use
+""")
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value =
+                            "TeamInvitationRepository.findInvitationDetailByTeamId : 팀 ID로 회사와 팀 정보를 조회합니다."))
+    Optional<TeamInvitationDetailResponse> findInvitationDetailByTeamId(
+            @Param("teamId") Long teamId, @Param("use") Boolean use);
+}

--- a/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
@@ -2,6 +2,7 @@ package com.moyorak.api.team.service;
 
 import com.moyorak.api.team.domain.InvitationToken;
 import com.moyorak.api.team.domain.TeamInvitation;
+import com.moyorak.api.team.domain.TeamInvitationTokenNotFoundException;
 import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.dto.TeamInvitationCreateResponse;
@@ -49,11 +50,16 @@ public class TeamInvitationService {
     }
 
     @Transactional(readOnly = true)
-    public TeamInvitationDetailResponse getInvitationDetail(final String invitationToken) {
+    public TeamInvitationDetailResponse getInvitationDetail(
+            final Long teamId, final String invitationToken) {
         final TeamInvitation teamInvitation =
                 teamInvitationRepository
                         .findByInvitationToken(invitationToken)
-                        .orElseThrow(() -> new BusinessException("토큰이 존재하지 않습니다."));
+                        .orElseThrow(TeamInvitationTokenNotFoundException::new);
+
+        if (teamInvitation.isNotInTeam(teamId)) {
+            throw new TeamInvitationTokenNotFoundException();
+        }
 
         if (teamInvitation.isExpired(LocalDateTime.now())) {
             throw new BusinessException("토큰이 만료되었습니다.");

--- a/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
@@ -5,8 +5,11 @@ import com.moyorak.api.team.domain.TeamInvitation;
 import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.dto.TeamInvitationCreateResponse;
+import com.moyorak.api.team.dto.TeamInvitationDetailResponse;
 import com.moyorak.api.team.repository.TeamInvitationRepository;
 import com.moyorak.api.team.repository.TeamUserRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,5 +46,21 @@ public class TeamInvitationService {
 
         final String invitationUrl = INVITATION_URL_PREFIX + teamInvitation.getInvitationToken();
         return TeamInvitationCreateResponse.of(invitationUrl);
+    }
+
+    @Transactional(readOnly = true)
+    public TeamInvitationDetailResponse getInvitationDetail(final String invitationToken) {
+        final TeamInvitation teamInvitation =
+                teamInvitationRepository
+                        .findByInvitationToken(invitationToken)
+                        .orElseThrow(() -> new BusinessException("토큰이 존재하지 않습니다."));
+
+        if (teamInvitation.isExpired(LocalDateTime.now())) {
+            throw new BusinessException("토큰이 만료되었습니다.");
+        }
+
+        return teamInvitationRepository
+                .findInvitationDetailByTeamId(teamInvitation.getTeamId(), true)
+                .orElseThrow(() -> new BusinessException("팀이 존재하지 않습니다."));
     }
 }

--- a/src/test/java/com/moyorak/api/team/domain/TeamInvitationFixture.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamInvitationFixture.java
@@ -1,0 +1,15 @@
+package com.moyorak.api.team.domain;
+
+import java.time.LocalDateTime;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TeamInvitationFixture {
+
+    public static TeamInvitation fixture(Long id, String token, LocalDateTime expiresDate) {
+        TeamInvitation teamInvitation = new TeamInvitation();
+        ReflectionTestUtils.setField(teamInvitation, "id", id);
+        ReflectionTestUtils.setField(teamInvitation, "invitationToken", token);
+        ReflectionTestUtils.setField(teamInvitation, "expiresDate", expiresDate);
+        return teamInvitation;
+    }
+}

--- a/src/test/java/com/moyorak/api/team/domain/TeamInvitationFixture.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamInvitationFixture.java
@@ -5,11 +5,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class TeamInvitationFixture {
 
-    public static TeamInvitation fixture(Long id, String token, LocalDateTime expiresDate) {
+    public static TeamInvitation fixture(
+            Long id, String token, LocalDateTime expiresDate, Long teamId) {
         TeamInvitation teamInvitation = new TeamInvitation();
         ReflectionTestUtils.setField(teamInvitation, "id", id);
         ReflectionTestUtils.setField(teamInvitation, "invitationToken", token);
         ReflectionTestUtils.setField(teamInvitation, "expiresDate", expiresDate);
+        ReflectionTestUtils.setField(teamInvitation, "teamId", teamId);
         return teamInvitation;
     }
 }

--- a/src/test/java/com/moyorak/api/team/domain/TeamInvitationTest.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamInvitationTest.java
@@ -15,7 +15,7 @@ class TeamInvitationTest {
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime expiresDate = now.minusSeconds(1);
         final TeamInvitation teamInvitation =
-                TeamInvitationFixture.fixture(1L, "token", expiresDate);
+                TeamInvitationFixture.fixture(1L, "token", expiresDate, 1L);
 
         // when
         final boolean result = teamInvitation.isExpired(now);

--- a/src/test/java/com/moyorak/api/team/domain/TeamInvitationTest.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamInvitationTest.java
@@ -1,0 +1,26 @@
+package com.moyorak.api.team.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TeamInvitationTest {
+
+    @Test
+    @DisplayName("토큰 만료가 되면 true를 반환한다.")
+    void isExpired() {
+        // given
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime expiresDate = now.minusSeconds(1);
+        final TeamInvitation teamInvitation =
+                TeamInvitationFixture.fixture(1L, "token", expiresDate);
+
+        // when
+        final boolean result = teamInvitation.isExpired(now);
+
+        // then
+        assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
@@ -5,11 +5,16 @@ import static org.mockito.BDDMockito.given;
 
 import com.moyorak.api.team.domain.Team;
 import com.moyorak.api.team.domain.TeamFixture;
+import com.moyorak.api.team.domain.TeamInvitation;
+import com.moyorak.api.team.domain.TeamInvitationFixture;
 import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserFixture;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.repository.TeamInvitationRepository;
 import com.moyorak.api.team.repository.TeamUserRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,6 +30,7 @@ class TeamInvitationServiceTest {
     @InjectMocks private TeamInvitationService teamInvitationService;
 
     @Mock private TeamUserRepository teamUserRepository;
+    @Mock private TeamInvitationRepository teamInvitationRepository;
 
     @Nested
     @DisplayName("초대 링크 생성 시")
@@ -61,6 +67,43 @@ class TeamInvitationServiceTest {
             assertThatThrownBy(() -> teamInvitationService.createTeamInvitation(teamId, userId))
                     .isInstanceOf(TeamUserNotFoundException.class)
                     .hasMessage("팀 멤버가 아닙니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("초대 링크 조회 시")
+    class GetInvitationDetail {
+
+        final String token = "sample-token";
+
+        @Test
+        @DisplayName("토큰이 존재하지 않으면 예외가 발생한다.")
+        void noToken() {
+            // given
+            given(teamInvitationRepository.findByInvitationToken(token))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> teamInvitationService.getInvitationDetail(token))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("토큰이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("토큰이 만료되었으면 예외가 발생한다.")
+        void tokenExpired() {
+            // given
+            LocalDateTime expiredExpiresDate = LocalDateTime.now().minusSeconds(1);
+            final TeamInvitation expiredInvitation =
+                    TeamInvitationFixture.fixture(1L, token, expiredExpiresDate);
+
+            given(teamInvitationRepository.findByInvitationToken(token))
+                    .willReturn(Optional.of(expiredInvitation));
+
+            // when & then
+            assertThatThrownBy(() -> teamInvitationService.getInvitationDetail(token))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("토큰이 만료되었습니다.");
         }
     }
 }

--- a/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
@@ -7,6 +7,7 @@ import com.moyorak.api.team.domain.Team;
 import com.moyorak.api.team.domain.TeamFixture;
 import com.moyorak.api.team.domain.TeamInvitation;
 import com.moyorak.api.team.domain.TeamInvitationFixture;
+import com.moyorak.api.team.domain.TeamInvitationTokenNotFoundException;
 import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserFixture;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
@@ -75,6 +76,7 @@ class TeamInvitationServiceTest {
     class GetInvitationDetail {
 
         final String token = "sample-token";
+        final Long teamId = 1L;
 
         @Test
         @DisplayName("토큰이 존재하지 않으면 예외가 발생한다.")
@@ -84,8 +86,8 @@ class TeamInvitationServiceTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> teamInvitationService.getInvitationDetail(token))
-                    .isInstanceOf(BusinessException.class)
+            assertThatThrownBy(() -> teamInvitationService.getInvitationDetail(teamId, token))
+                    .isInstanceOf(TeamInvitationTokenNotFoundException.class)
                     .hasMessage("토큰이 존재하지 않습니다.");
         }
 
@@ -95,13 +97,13 @@ class TeamInvitationServiceTest {
             // given
             LocalDateTime expiredExpiresDate = LocalDateTime.now().minusSeconds(1);
             final TeamInvitation expiredInvitation =
-                    TeamInvitationFixture.fixture(1L, token, expiredExpiresDate);
+                    TeamInvitationFixture.fixture(1L, token, expiredExpiresDate, teamId);
 
             given(teamInvitationRepository.findByInvitationToken(token))
                     .willReturn(Optional.of(expiredInvitation));
 
             // when & then
-            assertThatThrownBy(() -> teamInvitationService.getInvitationDetail(token))
+            assertThatThrownBy(() -> teamInvitationService.getInvitationDetail(teamId, token))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("토큰이 만료되었습니다.");
         }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팀 초대 api url에 안에 있는 토큰으로 검증 및 필요한 데이터 조회 기능 개발
- 테스트 코드 작성

---

## 📝 코멘트
- 화면 및 요구사항에 초대 링크로 초대시 가입까지 되는 흐름이 아니라 팀과 회사 정보만 내려주면 되기 때문에
필요한 데이터만 내려주도록 구현했습니다.
