### PR TITLE
feat: #145 본인 팀 탈퇴 기능 개발

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
@@ -1,0 +1,34 @@
+package com.moyorak.api.team.controller;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.team.service.TeamUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[팀 멤버] 팀 멤버 API", description = "팀 멤버 관련 API입니다.")
+class TeamUserController {
+
+    private final TeamUserService teamUserService;
+
+    @DeleteMapping("/teams/{teamId}/team-members/me")
+    @Operation(summary = "팀 탈퇴", description = "팀을 탈퇴합니다.")
+    public void withdraw(
+            @PathVariable @Positive final Long teamId,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        teamUserService.withdraw(userPrincipal.getId(), teamId);
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/TeamUser.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamUser.java
@@ -57,4 +57,13 @@ public class TeamUser extends AuditInformation {
     public boolean isNotApproved() {
         return status != TeamUserStatus.APPROVED;
     }
+
+    public boolean isTeamAdmin() {
+        return role == TeamRole.TEAM_ADMIN;
+    }
+
+    public void withdraw() {
+        status = TeamUserStatus.WITHDRAWN;
+        use = false;
+    }
 }

--- a/src/main/java/com/moyorak/api/team/service/TeamUserService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamUserService.java
@@ -1,0 +1,34 @@
+package com.moyorak.api.team.service;
+
+import com.moyorak.api.team.domain.TeamUser;
+import com.moyorak.api.team.domain.TeamUserNotFoundException;
+import com.moyorak.api.team.repository.TeamUserRepository;
+import com.moyorak.config.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamUserService {
+
+    private final TeamUserRepository teamUserRepository;
+
+    @Transactional
+    public void withdraw(final Long userId, final Long teamId) {
+        final TeamUser teamUser =
+                teamUserRepository
+                        .findByUserIdAndTeamIdAndUse(userId, teamId, true)
+                        .orElseThrow(TeamUserNotFoundException::new);
+
+        if (teamUser.isNotApproved()) {
+            throw new TeamUserNotFoundException();
+        }
+
+        if (teamUser.isTeamAdmin()) {
+            throw new BusinessException("팀 관리자는 탈퇴할 수 없습니다.");
+        }
+
+        teamUser.withdraw();
+    }
+}

--- a/src/test/java/com/moyorak/api/team/domain/TeamUserFixture.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamUserFixture.java
@@ -16,6 +16,16 @@ public class TeamUserFixture {
         return teamUser;
     }
 
+    public static TeamUser fixture(final TeamUserStatus status, final TeamRole role, boolean use) {
+        TeamUser teamUser = new TeamUser();
+
+        ReflectionTestUtils.setField(teamUser, "status", status);
+        ReflectionTestUtils.setField(teamUser, "role", role);
+        ReflectionTestUtils.setField(teamUser, "use", use);
+
+        return teamUser;
+    }
+
     public static TeamUser fixtureApproved(final Long userId, final Team team) {
         return fixture(userId, team, TeamUserStatus.APPROVED, true);
     }

--- a/src/test/java/com/moyorak/api/team/domain/TeamUserTest.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamUserTest.java
@@ -1,0 +1,96 @@
+package com.moyorak.api.team.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TeamUserTest {
+
+    @Nested
+    @DisplayName("isNotApproved 메서드는")
+    class IsNotApproved {
+
+        @Test
+        @DisplayName("status가 APPROVED가 아니면 true를 반환한다.")
+        void isTrue() {
+            // given
+            final TeamUser user =
+                    TeamUserFixture.fixture(TeamUserStatus.PENDING, TeamRole.TEAM_MEMBER, true);
+
+            // when
+            final boolean result = user.isNotApproved();
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("status가 APPROVED이면 false를 반환한다.")
+        void isFalse() {
+            // given
+            final TeamUser user =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
+
+            // when
+            final boolean result = user.isNotApproved();
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isTeamAdmin 메서드는")
+    class IsTeamAdmin {
+
+        @Test
+        @DisplayName("role이 TEAM_ADMIN이면 true를 반환한다.")
+        void isTrue() {
+            // given
+            final TeamUser user =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
+
+            // when
+            final boolean result = user.isTeamAdmin();
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("role이 TEAM_ADMIN이 아니면 false를 반환한다.")
+        void isFalse() {
+            // given
+            final TeamUser user =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
+
+            // when
+            final boolean result = user.isTeamAdmin();
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw 메서드는")
+    class Withdraw {
+
+        @Test
+        @DisplayName("status를 WITHDRAWN으로, use를 false로 변경한다.")
+        void updateStatusAndUse() {
+            // given
+            final TeamUser user =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
+
+            // when
+            user.withdraw();
+
+            // then
+            assertThat(user.isUse()).isFalse();
+            assertThat(user.getStatus()).isEqualTo(TeamUserStatus.WITHDRAWN);
+        }
+    }
+}

--- a/src/test/java/com/moyorak/api/team/service/TeamUserServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamUserServiceTest.java
@@ -1,0 +1,81 @@
+package com.moyorak.api.team.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.api.team.domain.TeamRole;
+import com.moyorak.api.team.domain.TeamUser;
+import com.moyorak.api.team.domain.TeamUserFixture;
+import com.moyorak.api.team.domain.TeamUserNotFoundException;
+import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.repository.TeamUserRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TeamUserServiceTest {
+
+    @InjectMocks private TeamUserService teamUserService;
+
+    @Mock private TeamUserRepository teamUserRepository;
+
+    @Nested
+    @DisplayName("withdraw 호출 시")
+    class Withdraw {
+
+        final Long teamId = 1L;
+        final Long userId = 1L;
+
+        @Test
+        @DisplayName("팀유저가 아닌 경우 TeamUserNotFoundException이 발생한다.")
+        void isNotExist() {
+            // given
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> teamUserService.withdraw(userId, teamId))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("팀유저 상태가 APPROVED가 아닌 경우 TeamUserNotFoundException이 발생한다.")
+        void isNotApproved() {
+            // given
+            final TeamUser pendingUser =
+                    TeamUserFixture.fixture(TeamUserStatus.PENDING, TeamRole.TEAM_MEMBER, true);
+
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
+                    .willReturn(Optional.of(pendingUser));
+
+            // when & then
+            assertThatThrownBy(() -> teamUserService.withdraw(userId, teamId))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("팀 관리자인 경우 BusinessException이 발생한다.")
+        void isAdmin() {
+            // given
+            final TeamUser teamAdminUser =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
+
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
+                    .willReturn(Optional.of(teamAdminUser));
+
+            // when & then
+            assertThatThrownBy(() -> teamUserService.withdraw(userId, teamId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("팀 관리자는 탈퇴할 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 본인 팀 탈퇴 기능 개발
- 테스트 코드 작성

---

## 📝 코멘트
- 본인 팀 탈퇴 시 가입되어 있는 경우만 진행되도록 구현했습니다.
- 본인이 팀 관리자라면 탈퇴를 못하도록 구현했습니다.(양도하고 탈퇴할 수 있도록)
