### PR TITLE
팀 맛집 삭제 시 팀 맛집 검색 에서 도 삭제

### DIFF
--- a/src/main/java/com/moyorak/api/team/domain/TeamRestaurantSearch.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamRestaurantSearch.java
@@ -52,6 +52,10 @@ public class TeamRestaurantSearch extends AuditInformation {
     @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
     private boolean use = true;
 
+    public void toggleUse() {
+        this.use = !this.use;
+    }
+
     public static TeamRestaurantSearch from(TeamRestaurant teamRestaurant, Restaurant restaurant) {
         TeamRestaurantSearch teamRestaurantSearch = new TeamRestaurantSearch();
 

--- a/src/main/java/com/moyorak/api/team/repository/TeamRestaurantSearchRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamRestaurantSearchRepository.java
@@ -1,6 +1,10 @@
 package com.moyorak.api.team.repository;
 
 import com.moyorak.api.team.domain.TeamRestaurantSearch;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamRestaurantSearchRepository extends JpaRepository<TeamRestaurantSearch, Long> {}
+public interface TeamRestaurantSearchRepository extends JpaRepository<TeamRestaurantSearch, Long> {
+    Optional<TeamRestaurantSearch> findByTeamIdAndTeamRestaurantId(
+            Long teamId, Long teamRestaurantId);
+}

--- a/src/main/java/com/moyorak/api/team/service/TeamRestaurantService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamRestaurantService.java
@@ -66,6 +66,14 @@ public class TeamRestaurantService {
         final TeamRestaurant teamRestaurant = getValidatedTeamRestaurant(teamId, teamRestaurantId);
         // 사용 여부 값 변경
         teamRestaurant.toggleUse();
+
+        final TeamRestaurantSearch teamRestaurantSearch =
+                teamRestaurantSearchRepository
+                        .findByTeamIdAndTeamRestaurantId(teamId, teamRestaurantId)
+                        .orElseThrow(() -> new BusinessException("팀 맛집 검색 데이터가 없습니다."));
+
+        // 사용 여부 값 변경
+        teamRestaurantSearch.toggleUse();
     }
 
     @Transactional

--- a/src/test/java/com/moyorak/api/team/domain/TeamRestaurantSearchFixture.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamRestaurantSearchFixture.java
@@ -1,0 +1,27 @@
+package com.moyorak.api.team.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TeamRestaurantSearchFixture {
+    public static TeamRestaurantSearch fixture(
+            Long teamRestaurantId,
+            double averageReviewScore,
+            double distanceFromTeam,
+            double longitude,
+            double latitude,
+            String name,
+            boolean use,
+            Long teamId) {
+        TeamRestaurantSearch teamRestaurantSearch = new TeamRestaurantSearch();
+        ReflectionTestUtils.setField(teamRestaurantSearch, "teamRestaurantId", teamRestaurantId);
+        ReflectionTestUtils.setField(
+                teamRestaurantSearch, "averageReviewScore", averageReviewScore);
+        ReflectionTestUtils.setField(teamRestaurantSearch, "distanceFromTeam", distanceFromTeam);
+        ReflectionTestUtils.setField(teamRestaurantSearch, "longitude", longitude);
+        ReflectionTestUtils.setField(teamRestaurantSearch, "latitude", latitude);
+        ReflectionTestUtils.setField(teamRestaurantSearch, "name", name);
+        ReflectionTestUtils.setField(teamRestaurantSearch, "use", use);
+        ReflectionTestUtils.setField(teamRestaurantSearch, "teamId", teamId);
+        return teamRestaurantSearch;
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팀 맛집 삭제 시, 팀 맛집 기록도 삭제

---

## 📝 코멘트
- 팀 맛집과 동일하게, 사용 유무 변경 토글 형식으로 개발
