### PR TITLE
feat: #155 본인 팀 맛집 상세 조회 기록 조회

### DIFF
--- a/src/main/java/com/moyorak/api/history/controller/ViewHistoryController.java
+++ b/src/main/java/com/moyorak/api/history/controller/ViewHistoryController.java
@@ -1,0 +1,37 @@
+package com.moyorak.api.history.controller;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.history.dto.ViewHistoryListResponse;
+import com.moyorak.api.history.dto.ViewHistoryRequest;
+import com.moyorak.api.history.service.ViewHistoryFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[기록] 팀 맛집 상세 조회 기록 API", description = "팀 맛집 상세 조회 기록 관리를 위한 API 입니다.")
+class ViewHistoryController {
+
+    private final ViewHistoryFacade viewHistoryFacade;
+
+    @GetMapping("/teams/{teamId}/team-members/me/view-history")
+    @Operation(summary = "자신의 팀 맛집 상세 조회 기록", description = "자신의 팀 맛집 상세 조회 기록을 조회합니다.")
+    public ViewHistoryListResponse getViewHistories(
+            @PathVariable @Positive final Long teamId,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        return viewHistoryFacade.getViewHistories(
+                ViewHistoryRequest.create(userPrincipal.getId(), teamId));
+    }
+}

--- a/src/main/java/com/moyorak/api/history/domain/ViewHistory.java
+++ b/src/main/java/com/moyorak/api/history/domain/ViewHistory.java
@@ -1,0 +1,43 @@
+package com.moyorak.api.history.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import com.moyorak.infra.orm.BooleanYnConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "view_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ViewHistory extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("사용 여부")
+    @Convert(converter = BooleanYnConverter.class)
+    @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
+    private boolean use = true;
+
+    @Comment("팀 고유 ID")
+    @Column(name = "team_id", nullable = false)
+    private Long teamId;
+
+    @Comment("유저 고유 ID")
+    @Column(name = "member_id", nullable = false)
+    private Long userId;
+
+    @Comment("팀 고유 ID")
+    @Column(name = "team_restaurant_id", nullable = false)
+    private Long teamRestaurantId;
+}

--- a/src/main/java/com/moyorak/api/history/dto/ViewHistoryListResponse.java
+++ b/src/main/java/com/moyorak/api/history/dto/ViewHistoryListResponse.java
@@ -1,0 +1,67 @@
+package com.moyorak.api.history.dto;
+
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+import com.moyorak.api.review.domain.FirstReviewPhotoPaths;
+import com.moyorak.api.team.domain.TeamRestaurantSummaries;
+import com.moyorak.api.team.dto.TeamRestaurantSummary;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Schema(title = "팀 맛집 상세 조회 기록 리스트 응답 DTO")
+public record ViewHistoryListResponse(
+        @ArraySchema(
+                        schema =
+                                @Schema(
+                                        description = "조회 기록",
+                                        implementation = ViewHistoryResponse.class),
+                        arraySchema = @Schema(description = "조회 기록 응답 리스트"))
+                List<ViewHistoryResponse> viewHistories) {
+    public static ViewHistoryListResponse from(
+            final ViewHistorySummaries viewHistorySummaries,
+            final TeamRestaurantSummaries teamRestaurantSummaries,
+            final FirstReviewPhotoPaths firstReviewPhotoPaths) {
+        final Map<Long, TeamRestaurantSummary> teamRestaurantSummaryMap =
+                teamRestaurantSummaries.getSummaries().stream()
+                        .collect(
+                                Collectors.toUnmodifiableMap(
+                                        TeamRestaurantSummary::teamRestaurantId,
+                                        Function.identity()));
+
+        final List<ViewHistoryResponse> viewHistoryListResponse =
+                viewHistorySummaries.summaries().stream()
+                        .map(
+                                viewHistorySummary -> {
+                                    final TeamRestaurantSummary teamRestaurantSummary =
+                                            teamRestaurantSummaryMap.get(
+                                                    viewHistorySummary.teamRestaurantId());
+                                    // 팀 식당이 존재하지 않는 경우
+                                    if (teamRestaurantSummary == null) {
+                                        return ViewHistoryResponse.create(
+                                                viewHistorySummary.id(),
+                                                0L,
+                                                "",
+                                                RestaurantCategory.ETC,
+                                                0.0,
+                                                0,
+                                                null);
+                                    }
+
+                                    return ViewHistoryResponse.create(
+                                            viewHistorySummary.id(),
+                                            teamRestaurantSummary.teamRestaurantId(),
+                                            teamRestaurantSummary.restaurantName(),
+                                            teamRestaurantSummary.restaurantCategory(),
+                                            teamRestaurantSummary.averageReviewScore(),
+                                            teamRestaurantSummary.reviewCount(),
+                                            firstReviewPhotoPaths.getPhotoPath(
+                                                    teamRestaurantSummary.teamRestaurantId()));
+                                })
+                        .toList();
+
+        return new ViewHistoryListResponse(viewHistoryListResponse);
+    }
+}

--- a/src/main/java/com/moyorak/api/history/dto/ViewHistoryRequest.java
+++ b/src/main/java/com/moyorak/api/history/dto/ViewHistoryRequest.java
@@ -1,0 +1,19 @@
+package com.moyorak.api.history.dto;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record ViewHistoryRequest(Long userId, Long teamId) {
+    private static final int FIXED_PAGE_NUMBER = 0;
+    private static final int FIXED_PAGE_SIZE = 5;
+
+    public static ViewHistoryRequest create(final Long userId, final Long teamId) {
+        return new ViewHistoryRequest(userId, teamId);
+    }
+
+    public Pageable toRecentPageable() {
+        return PageRequest.of(
+                FIXED_PAGE_NUMBER, FIXED_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "id"));
+    }
+}

--- a/src/main/java/com/moyorak/api/history/dto/ViewHistoryResponse.java
+++ b/src/main/java/com/moyorak/api/history/dto/ViewHistoryResponse.java
@@ -1,0 +1,33 @@
+package com.moyorak.api.history.dto;
+
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "팀 맛집 상세 조회 기록 응답 DTO")
+public record ViewHistoryResponse(
+        @Schema(description = "조회 기록 ID", example = "3") Long viewHistoryId,
+        @Schema(description = "팀 식당 ID", example = "3") Long teamRestaurantId,
+        @Schema(description = "식당 이름", example = "김밥 천국") String restaurantName,
+        @Schema(description = "식당 카테고리", example = "KOREAN") RestaurantCategory restaurantCategory,
+        @Schema(description = "리뷰 평균 점수", example = "4.3") double averageReviewScore,
+        @Schema(description = "리뷰 숫자", example = "50") int reviewCount,
+        @Schema(description = "리뷰 이미지 path", example = "https://somepath/review.jpg")
+                String reviewImagePath) {
+    public static ViewHistoryResponse create(
+            Long viewHistoryId,
+            Long teamRestaurantId,
+            String restaurantName,
+            RestaurantCategory restaurantCategory,
+            Double averageReviewScore,
+            int reviewCount,
+            String reviewImagePath) {
+        return new ViewHistoryResponse(
+                viewHistoryId,
+                teamRestaurantId,
+                restaurantName,
+                restaurantCategory,
+                averageReviewScore,
+                reviewCount,
+                reviewImagePath);
+    }
+}

--- a/src/main/java/com/moyorak/api/history/dto/ViewHistorySummaries.java
+++ b/src/main/java/com/moyorak/api/history/dto/ViewHistorySummaries.java
@@ -1,0 +1,15 @@
+package com.moyorak.api.history.dto;
+
+import com.moyorak.api.history.domain.ViewHistory;
+import java.util.List;
+
+public record ViewHistorySummaries(List<ViewHistorySummary> summaries) {
+    public static ViewHistorySummaries from(final List<ViewHistory> viewHistories) {
+        return new ViewHistorySummaries(
+                viewHistories.stream().map(ViewHistorySummary::from).toList());
+    }
+
+    public List<Long> getTeamRestaurantIds() {
+        return summaries.stream().map(ViewHistorySummary::teamRestaurantId).toList();
+    }
+}

--- a/src/main/java/com/moyorak/api/history/dto/ViewHistorySummary.java
+++ b/src/main/java/com/moyorak/api/history/dto/ViewHistorySummary.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.history.dto;
+
+import com.moyorak.api.history.domain.ViewHistory;
+
+public record ViewHistorySummary(Long id, Long teamRestaurantId) {
+    public static ViewHistorySummary from(final ViewHistory viewHistory) {
+        return new ViewHistorySummary(viewHistory.getId(), viewHistory.getTeamRestaurantId());
+    }
+}

--- a/src/main/java/com/moyorak/api/history/repository/ViewHistoryRepository.java
+++ b/src/main/java/com/moyorak/api/history/repository/ViewHistoryRepository.java
@@ -1,0 +1,19 @@
+package com.moyorak.api.history.repository;
+
+import com.moyorak.api.history.domain.ViewHistory;
+import jakarta.persistence.QueryHint;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.QueryHints;
+
+public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> {
+
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value =
+                            "ViewHistoryRepository.findAllByUserIdAndTeamIdAndUse : 팀 맛집 상세 조회 기록 리스트를 조회합니다."))
+    List<ViewHistory> findAllByUserIdAndTeamIdAndUse(
+            Long userId, Long teamId, boolean use, Pageable pageable);
+}

--- a/src/main/java/com/moyorak/api/history/service/ViewHistoryFacade.java
+++ b/src/main/java/com/moyorak/api/history/service/ViewHistoryFacade.java
@@ -1,0 +1,40 @@
+package com.moyorak.api.history.service;
+
+import com.moyorak.api.history.dto.ViewHistoryListResponse;
+import com.moyorak.api.history.dto.ViewHistoryRequest;
+import com.moyorak.api.history.dto.ViewHistorySummaries;
+import com.moyorak.api.review.domain.FirstReviewPhotoPaths;
+import com.moyorak.api.review.service.ReviewPhotoService;
+import com.moyorak.api.team.domain.TeamRestaurantSummaries;
+import com.moyorak.api.team.service.TeamRestaurantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ViewHistoryFacade {
+
+    private final ViewHistoryService viewHistoryService;
+    private final TeamRestaurantService teamRestaurantService;
+    private final ReviewPhotoService reviewPhotoService;
+
+    @Transactional(readOnly = true)
+    public ViewHistoryListResponse getViewHistories(final ViewHistoryRequest request) {
+        final ViewHistorySummaries viewHistorySummaries =
+                viewHistoryService.getViewHistorySummaries(request);
+
+        // 팀 식당 id로 필요한 정보 가져오기
+        final TeamRestaurantSummaries teamRestaurantSummaries =
+                teamRestaurantService.findByIdsAndUse(
+                        viewHistorySummaries.getTeamRestaurantIds(), true);
+
+        // 팀 식당별로 리뷰 첫 사진 정보 가져오기
+        final FirstReviewPhotoPaths firstReviewPhotoPaths =
+                reviewPhotoService.findFirstReviewPhotoPaths(
+                        teamRestaurantSummaries.getTeamRestaurantIds());
+
+        return ViewHistoryListResponse.from(
+                viewHistorySummaries, teamRestaurantSummaries, firstReviewPhotoPaths);
+    }
+}

--- a/src/main/java/com/moyorak/api/history/service/ViewHistoryService.java
+++ b/src/main/java/com/moyorak/api/history/service/ViewHistoryService.java
@@ -1,0 +1,25 @@
+package com.moyorak.api.history.service;
+
+import com.moyorak.api.history.domain.ViewHistory;
+import com.moyorak.api.history.dto.ViewHistoryRequest;
+import com.moyorak.api.history.dto.ViewHistorySummaries;
+import com.moyorak.api.history.repository.ViewHistoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ViewHistoryService {
+
+    private final ViewHistoryRepository viewHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public ViewHistorySummaries getViewHistorySummaries(final ViewHistoryRequest request) {
+        final List<ViewHistory> viewHistories =
+                viewHistoryRepository.findAllByUserIdAndTeamIdAndUse(
+                        request.userId(), request.teamId(), true, request.toRecentPageable());
+        return ViewHistorySummaries.from(viewHistories);
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/TeamRestaurantSummaries.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamRestaurantSummaries.java
@@ -5,7 +5,9 @@ import com.moyorak.api.team.dto.TeamRestaurantListResponse;
 import com.moyorak.api.team.dto.TeamRestaurantSearchResponse;
 import com.moyorak.api.team.dto.TeamRestaurantSummary;
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class TeamRestaurantSummaries {
 
     private final List<TeamRestaurantSummary> summaries;

--- a/src/test/java/com/moyorak/api/history/domain/ViewHistoryFixture.java
+++ b/src/test/java/com/moyorak/api/history/domain/ViewHistoryFixture.java
@@ -1,0 +1,24 @@
+package com.moyorak.api.history.domain;
+
+import java.time.LocalDateTime;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ViewHistoryFixture {
+
+    public static ViewHistory fixture(
+            final Long id,
+            final Long teamId,
+            final Long userId,
+            final Long teamRestaurantId,
+            final LocalDateTime createdDate) {
+        ViewHistory viewHistory = new ViewHistory();
+
+        ReflectionTestUtils.setField(viewHistory, "id", id);
+        ReflectionTestUtils.setField(viewHistory, "teamId", teamId);
+        ReflectionTestUtils.setField(viewHistory, "userId", userId);
+        ReflectionTestUtils.setField(viewHistory, "teamRestaurantId", teamRestaurantId);
+        ReflectionTestUtils.setField(viewHistory, "createdDate", createdDate);
+
+        return viewHistory;
+    }
+}

--- a/src/test/java/com/moyorak/api/history/service/ViewHistoryFacadeTest.java
+++ b/src/test/java/com/moyorak/api/history/service/ViewHistoryFacadeTest.java
@@ -1,0 +1,162 @@
+package com.moyorak.api.history.service;
+
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.api.history.dto.ViewHistoryListResponse;
+import com.moyorak.api.history.dto.ViewHistoryRequest;
+import com.moyorak.api.history.dto.ViewHistorySummaries;
+import com.moyorak.api.history.dto.ViewHistorySummary;
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+import com.moyorak.api.review.domain.FirstReviewPhotoPaths;
+import com.moyorak.api.review.dto.FirstReviewPhotoPath;
+import com.moyorak.api.review.service.ReviewPhotoService;
+import com.moyorak.api.team.domain.TeamRestaurantSummaries;
+import com.moyorak.api.team.dto.TeamRestaurantSummary;
+import com.moyorak.api.team.service.TeamRestaurantService;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ViewHistoryFacadeTest {
+
+    @InjectMocks private ViewHistoryFacade viewHistoryFacade;
+
+    @Mock private ViewHistoryService viewHistoryService;
+
+    @Mock private TeamRestaurantService teamRestaurantService;
+
+    @Mock private ReviewPhotoService reviewPhotoService;
+
+    @Nested
+    @DisplayName("팀 맛집 뷰 기록 Facade 조회 시")
+    class GetViewHistories {
+
+        final Long userId = 1L;
+        final Long teamId = 1L;
+        final Long teamRestaurantId1 = 1L;
+        final Long teamRestaurantId2 = 2L;
+        final ViewHistoryRequest request = ViewHistoryRequest.create(userId, teamId);
+
+        @Test
+        @DisplayName("최신 순으로 반환된다.")
+        void success() {
+            // given
+            final ViewHistorySummary summary1 = new ViewHistorySummary(1L, teamRestaurantId1);
+            final ViewHistorySummary summary2 = new ViewHistorySummary(2L, teamRestaurantId2);
+            final ViewHistorySummaries viewHistorySummaries =
+                    new ViewHistorySummaries(List.of(summary2, summary1));
+
+            given(viewHistoryService.getViewHistorySummaries(request))
+                    .willReturn(viewHistorySummaries);
+
+            final TeamRestaurantSummary teamRestaurant1 =
+                    new TeamRestaurantSummary(
+                            teamRestaurantId1, "식당1", RestaurantCategory.KOREAN, 4.5, 10);
+            final TeamRestaurantSummary teamRestaurant2 =
+                    new TeamRestaurantSummary(
+                            teamRestaurantId2, "식당2", RestaurantCategory.CHINESE, 4.0, 8);
+            final TeamRestaurantSummaries teamRestaurantSummaries =
+                    TeamRestaurantSummaries.create(List.of(teamRestaurant2, teamRestaurant1));
+
+            given(
+                            teamRestaurantService.findByIdsAndUse(
+                                    viewHistorySummaries.getTeamRestaurantIds(), true))
+                    .willReturn(teamRestaurantSummaries);
+
+            final FirstReviewPhotoPaths firstReviewPhotoPaths =
+                    FirstReviewPhotoPaths.create(
+                            teamRestaurantSummaries.getTeamRestaurantIds(),
+                            List.of(
+                                    new FirstReviewPhotoPath(teamRestaurantId2, "path2.jpg"),
+                                    new FirstReviewPhotoPath(teamRestaurantId1, "path1.jpg")));
+
+            given(
+                            reviewPhotoService.findFirstReviewPhotoPaths(
+                                    teamRestaurantSummaries.getTeamRestaurantIds()))
+                    .willReturn(firstReviewPhotoPaths);
+
+            // when
+            final ViewHistoryListResponse result = viewHistoryFacade.getViewHistories(request);
+
+            // then
+            SoftAssertions.assertSoftly(
+                    it -> {
+                        it.assertThat(result.viewHistories()).hasSize(2);
+                        it.assertThat(result.viewHistories())
+                                .extracting("teamRestaurantId")
+                                .containsExactly(2L, 1L);
+                    });
+        }
+
+        @Test
+        @DisplayName("팀 레스토랑 정보가 없으면 디폴트 값으로 반환된다.")
+        void returnDefault() {
+            // given
+            final ViewHistorySummary summary1 = new ViewHistorySummary(1L, teamRestaurantId1);
+            final ViewHistorySummary summary2 = new ViewHistorySummary(2L, teamRestaurantId2);
+            final ViewHistorySummaries viewHistorySummaries =
+                    new ViewHistorySummaries(List.of(summary2, summary1));
+
+            given(viewHistoryService.getViewHistorySummaries(request))
+                    .willReturn(viewHistorySummaries);
+
+            // 팀 레스토랑이 1개만 존재할때
+            final TeamRestaurantSummaries teamRestaurantSummaries =
+                    TeamRestaurantSummaries.create(
+                            List.of(
+                                    new TeamRestaurantSummary(
+                                            teamRestaurantId1,
+                                            "식당1",
+                                            RestaurantCategory.KOREAN,
+                                            4.5,
+                                            10)));
+            given(
+                            teamRestaurantService.findByIdsAndUse(
+                                    viewHistorySummaries.getTeamRestaurantIds(), true))
+                    .willReturn(teamRestaurantSummaries);
+
+            final FirstReviewPhotoPaths firstReviewPhotoPaths =
+                    FirstReviewPhotoPaths.create(
+                            teamRestaurantSummaries.getTeamRestaurantIds(), List.of());
+            given(
+                            reviewPhotoService.findFirstReviewPhotoPaths(
+                                    teamRestaurantSummaries.getTeamRestaurantIds()))
+                    .willReturn(firstReviewPhotoPaths);
+
+            // when
+            final ViewHistoryListResponse result = viewHistoryFacade.getViewHistories(request);
+
+            // then
+            SoftAssertions.assertSoftly(
+                    it -> {
+                        it.assertThat(result.viewHistories()).hasSize(2);
+                        it.assertThat(result.viewHistories())
+                                .extracting("restaurantName")
+                                .containsExactly("", "식당1");
+
+                        it.assertThat(result.viewHistories())
+                                .extracting("restaurantCategory")
+                                .containsExactly(RestaurantCategory.ETC, RestaurantCategory.KOREAN);
+
+                        it.assertThat(result.viewHistories())
+                                .extracting("averageReviewScore")
+                                .containsExactly(0.0, 4.5);
+
+                        it.assertThat(result.viewHistories())
+                                .extracting("reviewCount")
+                                .containsExactly(0, 10);
+
+                        it.assertThat(result.viewHistories())
+                                .extracting("reviewImagePath")
+                                .containsExactly(null, null);
+                    });
+        }
+    }
+}

--- a/src/test/java/com/moyorak/api/history/service/ViewHistoryServiceTest.java
+++ b/src/test/java/com/moyorak/api/history/service/ViewHistoryServiceTest.java
@@ -1,0 +1,61 @@
+package com.moyorak.api.history.service;
+
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.api.history.domain.ViewHistory;
+import com.moyorak.api.history.domain.ViewHistoryFixture;
+import com.moyorak.api.history.dto.ViewHistoryRequest;
+import com.moyorak.api.history.dto.ViewHistorySummaries;
+import com.moyorak.api.history.repository.ViewHistoryRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ViewHistoryServiceTest {
+
+    @InjectMocks private ViewHistoryService viewHistoryService;
+
+    @Mock private ViewHistoryRepository viewHistoryRepository;
+
+    @Nested
+    @DisplayName("팀 맛집 뷰 기록 조회 시")
+    class GetViewHistories {
+
+        final Long userId = 1L;
+        final Long teamId = 1L;
+        final ViewHistoryRequest request = ViewHistoryRequest.create(userId, teamId);
+
+        @Test
+        @DisplayName("뷰 기록이 최신 순으로 반환된다.")
+        void success() {
+            // given
+            final LocalDateTime now = LocalDateTime.now();
+            final ViewHistory history1 =
+                    ViewHistoryFixture.fixture(1L, teamId, userId, 1L, now.minusSeconds(1));
+            final ViewHistory history2 = ViewHistoryFixture.fixture(2L, teamId, userId, 2L, now);
+
+            given(
+                            viewHistoryRepository.findAllByUserIdAndTeamIdAndUse(
+                                    userId, teamId, true, request.toRecentPageable()))
+                    .willReturn(List.of(history2, history1));
+
+            // when
+            final ViewHistorySummaries result = viewHistoryService.getViewHistorySummaries(request);
+
+            // then
+            SoftAssertions.assertSoftly(
+                    it -> {
+                        it.assertThat(result.summaries()).hasSize(2);
+                        it.assertThat(result.summaries()).extracting("id").containsExactly(2L, 1L);
+                    });
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 자신의 팀 맛집 상세 조회 기록 리스트 조회 기능 개발

---

## 📝 코멘트
자신의 조회 기록을 조회하는 기능을 개발했습니다.
팀 식당 테이블과 기록 테이블이 논리적 데이터의 정합성이 맞지 않을 수 있는(소프트 딜리트이기 때문에) 상황이 있을 수도 있기에 
팀 식당 테이블에 데이터가 없는 경우에는 응답 데이터에 기본 값을 채워 넣었습니다.(사용자가 이상을 감지하고 삭제할 수 있도록 하기 위해)
