### PR TITLE
feat: #169 팀 맛집 상세 조회 시 본인 조회 기록에 저장

### DIFF
--- a/src/main/java/com/moyorak/api/history/domain/ViewHistory.java
+++ b/src/main/java/com/moyorak/api/history/domain/ViewHistory.java
@@ -40,4 +40,15 @@ public class ViewHistory extends AuditInformation {
     @Comment("팀 고유 ID")
     @Column(name = "team_restaurant_id", nullable = false)
     private Long teamRestaurantId;
+
+    public static ViewHistory create(
+            final Long userId, final Long teamId, final Long teamRestaurantId) {
+        ViewHistory viewHistory = new ViewHistory();
+
+        viewHistory.userId = userId;
+        viewHistory.teamId = teamId;
+        viewHistory.teamRestaurantId = teamRestaurantId;
+
+        return viewHistory;
+    }
 }

--- a/src/main/java/com/moyorak/api/history/service/HistoryEventHandler.java
+++ b/src/main/java/com/moyorak/api/history/service/HistoryEventHandler.java
@@ -1,8 +1,11 @@
 package com.moyorak.api.history.service;
 
 import com.moyorak.api.history.domain.SearchHistory;
+import com.moyorak.api.history.domain.ViewHistory;
 import com.moyorak.api.history.repository.SearchHistoryRepository;
+import com.moyorak.api.history.repository.ViewHistoryRepository;
 import com.moyorak.api.team.dto.TeamRestaurantSearchEvent;
+import com.moyorak.api.team.dto.TeamRestaurantViewEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -15,6 +18,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class HistoryEventHandler {
 
     private final SearchHistoryRepository searchHistoryRepository;
+    private final ViewHistoryRepository viewHistoryRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -22,5 +26,13 @@ public class HistoryEventHandler {
         final SearchHistory searchHistory =
                 SearchHistory.create(event.keyword(), event.teamId(), event.userId());
         searchHistoryRepository.save(searchHistory);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleViewEvent(final TeamRestaurantViewEvent event) {
+        final ViewHistory viewHistory =
+                ViewHistory.create(event.userId(), event.teamId(), event.teamRestaurantId());
+        viewHistoryRepository.save(viewHistory);
     }
 }

--- a/src/main/java/com/moyorak/api/team/controller/TeamRestaurantController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamRestaurantController.java
@@ -60,8 +60,10 @@ class TeamRestaurantController {
     @Operation(summary = "팀 맛집 상세 조회", description = "팀 맛집 상세 조회를 합니다.")
     public TeamRestaurantResponse getTeamRestaurant(
             @PathVariable @Positive final Long teamId,
-            @PathVariable @Positive final Long teamRestaurantId) {
-        return teamRestaurantService.getTeamRestaurant(teamId, teamRestaurantId);
+            @PathVariable @Positive final Long teamRestaurantId,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        return teamRestaurantService.getTeamRestaurant(
+                userPrincipal.getId(), teamId, teamRestaurantId);
     }
 
     @PutMapping("/{teamId}/restaurants/{teamRestaurantId}")

--- a/src/main/java/com/moyorak/api/team/dto/TeamRestaurantViewEvent.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamRestaurantViewEvent.java
@@ -1,0 +1,7 @@
+package com.moyorak.api.team.dto;
+
+public record TeamRestaurantViewEvent(Long userId, Long teamId, Long teamRestaurantId) {
+    public static TeamRestaurantViewEvent create(Long userId, Long teamId, Long teamRestaurantId) {
+        return new TeamRestaurantViewEvent(userId, teamId, teamRestaurantId);
+    }
+}

--- a/src/main/java/com/moyorak/api/team/service/TeamRestaurantEventPublisher.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamRestaurantEventPublisher.java
@@ -1,6 +1,7 @@
 package com.moyorak.api.team.service;
 
 import com.moyorak.api.team.dto.TeamRestaurantSearchEvent;
+import com.moyorak.api.team.dto.TeamRestaurantViewEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -13,5 +14,10 @@ public class TeamRestaurantEventPublisher {
 
     public void publishSearchEvent(final Long userId, final Long teamId, final String keyword) {
         publisher.publishEvent(TeamRestaurantSearchEvent.of(userId, teamId, keyword));
+    }
+
+    public void publishViewEvent(
+            final Long userId, final Long teamId, final Long teamRestaurantId) {
+        publisher.publishEvent(TeamRestaurantViewEvent.create(userId, teamId, teamRestaurantId));
     }
 }

--- a/src/main/java/com/moyorak/api/team/service/TeamRestaurantService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamRestaurantService.java
@@ -32,11 +32,15 @@ public class TeamRestaurantService {
     private final TeamUserRepository teamUserRepository;
     private final RestaurantRepository restaurantRepository;
     private final TeamRestaurantSearchRepository teamRestaurantSearchRepository;
+    private final TeamRestaurantEventPublisher teamRestaurantEventPublisher;
 
     @Transactional(readOnly = true)
-    public TeamRestaurantResponse getTeamRestaurant(Long teamId, Long teamRestaurantId) {
+    public TeamRestaurantResponse getTeamRestaurant(
+            Long userId, Long teamId, Long teamRestaurantId) {
         final TeamRestaurant teamRestaurant = getValidatedTeamRestaurant(teamId, teamRestaurantId);
 
+        // 조회 이벤트 발행
+        teamRestaurantEventPublisher.publishViewEvent(userId, teamId, teamRestaurantId);
         return TeamRestaurantResponse.from(teamRestaurant);
     }
 

--- a/src/test/java/com/moyorak/api/team/service/TeamRestaurantServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamRestaurantServiceTest.java
@@ -49,9 +49,11 @@ class TeamRestaurantServiceTest {
     @Mock private TeamUserRepository teamUserRepository;
     @Mock private RestaurantRepository restaurantRepository;
     @Mock private TeamRestaurantSearchRepository teamRestaurantSearchRepository;
+    @Mock private TeamRestaurantEventPublisher teamRestaurantEventPublisher;
 
     final Long teamId = 1L;
     final Long teamRestaurantId = 1L;
+    final Long userId = 1L;
 
     @Nested
     @DisplayName("팀 맛집 상세 조회 시,")
@@ -78,7 +80,7 @@ class TeamRestaurantServiceTest {
 
             // when
             final TeamRestaurantResponse response =
-                    teamRestaurantService.getTeamRestaurant(teamId, teamRestaurantId);
+                    teamRestaurantService.getTeamRestaurant(userId, teamId, teamRestaurantId);
 
             // then
             assertThat(response.name()).isEqualTo(teamRestaurant.getRestaurant().getName());
@@ -93,7 +95,9 @@ class TeamRestaurantServiceTest {
 
             // when & then
             assertThatThrownBy(
-                            () -> teamRestaurantService.getTeamRestaurant(teamId, teamRestaurantId))
+                            () ->
+                                    teamRestaurantService.getTeamRestaurant(
+                                            userId, teamId, teamRestaurantId))
                     .isInstanceOf(TeamRestaurantNotFoundException.class);
         }
 
@@ -110,7 +114,9 @@ class TeamRestaurantServiceTest {
 
             // when & then
             assertThatThrownBy(
-                            () -> teamRestaurantService.getTeamRestaurant(teamId, teamRestaurantId))
+                            () ->
+                                    teamRestaurantService.getTeamRestaurant(
+                                            userId, teamId, teamRestaurantId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("연결된 식당 정보가 존재하지 않습니다.");
         }
@@ -145,7 +151,9 @@ class TeamRestaurantServiceTest {
 
             // when & then
             assertThatThrownBy(
-                            () -> teamRestaurantService.getTeamRestaurant(teamId, teamRestaurantId))
+                            () ->
+                                    teamRestaurantService.getTeamRestaurant(
+                                            userId, teamId, teamRestaurantId))
                     .isInstanceOf(TeamRestaurantNotFoundException.class);
         }
     }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 이벤트 처리 기반의 조회 저장 기능 개발
- 기능 추가로 인한 기존 팀 맛집 조회에 필요한 파라미터 추가
- 테스트 코드 수정

---

## 📝 코멘트
이벤트 처리 기반으로 팀 맛집 조회 시 조회 기록을 저장하는 기능을 개발했습니다.
