### PR TITLE
refactor: #170 초대 링크 생성에서 토큰 생성으로 변경

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamInvitationController.java
@@ -28,7 +28,7 @@ class TeamInvitationController {
     private final TeamInvitationService teamInvitationService;
 
     @PostMapping("/teams/{teamId}/invitation")
-    @Operation(summary = "팀 초대 링크 생성", description = "팀 초대를 위한 링크를 생성합니다.")
+    @Operation(summary = "팀 초대 링크 토큰 생성", description = "팀 초대를 위한 링크 토큰을 생성합니다.")
     public TeamInvitationCreateResponse createTeamInvitation(
             @PathVariable @Positive final Long teamId,
             @AuthenticationPrincipal final UserPrincipal userPrincipal) {

--- a/src/main/java/com/moyorak/api/team/dto/TeamInvitationCreateResponse.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamInvitationCreateResponse.java
@@ -2,11 +2,10 @@ package com.moyorak.api.team.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(title = "[팀 초대] 팀 초대 링크 생성 응답 DTO")
+@Schema(title = "[팀 초대] 팀 초대 링크 토큰 생성 응답 DTO")
 public record TeamInvitationCreateResponse(
-        @Schema(description = "팀 초대 링크 URL 주소", example = "http://moyorak/invitation/abcdefg-asddf")
-                String invitationUrl) {
-    public static TeamInvitationCreateResponse of(String invitationUrl) {
-        return new TeamInvitationCreateResponse(invitationUrl);
+        @Schema(description = "팀 초대 링크 토큰", example = "abcdefg-asddf") String invitationToken) {
+    public static TeamInvitationCreateResponse of(String invitationToken) {
+        return new TeamInvitationCreateResponse(invitationToken);
     }
 }

--- a/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamInvitationService.java
@@ -22,9 +22,6 @@ public class TeamInvitationService {
     private final TeamInvitationRepository teamInvitationRepository;
     private final TeamUserRepository teamUserRepository;
 
-    // TODO 프론트에서 사용할 URL로 교체해야함 OR 그냥 토큰만 내려주기(프론트에서 전체 링크 생성)
-    private static final String INVITATION_URL_PREFIX = "http://moyorak/invitation/";
-
     @Transactional
     public TeamInvitationCreateResponse createTeamInvitation(final Long teamId, final Long userId) {
 
@@ -45,8 +42,7 @@ public class TeamInvitationService {
                         invitationToken.token(), invitationToken.expiresDate(), teamId);
         teamInvitationRepository.save(teamInvitation);
 
-        final String invitationUrl = INVITATION_URL_PREFIX + teamInvitation.getInvitationToken();
-        return TeamInvitationCreateResponse.of(invitationUrl);
+        return TeamInvitationCreateResponse.of(teamInvitation.getInvitationToken());
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamInvitationServiceTest.java
@@ -34,7 +34,7 @@ class TeamInvitationServiceTest {
     @Mock private TeamInvitationRepository teamInvitationRepository;
 
     @Nested
-    @DisplayName("초대 링크 생성 시")
+    @DisplayName("초대 링크 토큰 생성 시")
     class Create {
 
         final Long teamId = 1L;


### PR DESCRIPTION
## 📌 주요 변경 사항
- 초대 링크 생성에서 토큰 생성으로 변경

---

## 📝 코멘트
프론트 부분에서 링크를 생성해주고 백엔드 부분에서 토큰 생성만 담당하도록 변경해주었습니다.
(초대 링크 URL이 프론트 라우팅 URL로 생성되어야하기 때문)
