### PR TITLE
feat: #177 리뷰 대기시간,서빙시간 조회

### DIFF
--- a/src/main/java/com/moyorak/api/review/controller/ReviewController.java
+++ b/src/main/java/com/moyorak/api/review/controller/ReviewController.java
@@ -1,0 +1,31 @@
+package com.moyorak.api.review.controller;
+
+import com.moyorak.api.review.dto.ReviewServingTimeResponse;
+import com.moyorak.api.review.dto.ReviewWaitingTimeResponse;
+import com.moyorak.api.review.service.ReviewService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[리뷰] 리뷰 API", description = "리뷰를 위한 API 입니다.")
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @GetMapping("/reviews/serving-time")
+    public List<ReviewServingTimeResponse> getReviewServingTime() {
+        return reviewService.getReviewServingTime();
+    }
+
+    @GetMapping("/reviews/waiting-time")
+    public List<ReviewWaitingTimeResponse> getReviewWaitingTime() {
+        return reviewService.getReviewWaitingTime();
+    }
+}

--- a/src/main/java/com/moyorak/api/review/domain/ReviewServingTime.java
+++ b/src/main/java/com/moyorak/api/review/domain/ReviewServingTime.java
@@ -1,0 +1,39 @@
+package com.moyorak.api.review.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import com.moyorak.infra.orm.BooleanYnConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "review_serving_time")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewServingTime extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("준비 시간")
+    @Column(name = "serving_time", nullable = false, columnDefinition = "varchar(50)")
+    private String servingTime;
+
+    @Comment("준비 시간 값")
+    @Column(name = "serving_time_value", nullable = false)
+    private Integer servingTimeValue;
+
+    @Comment("사용 여부")
+    @Convert(converter = BooleanYnConverter.class)
+    @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
+    private boolean use = true;
+}

--- a/src/main/java/com/moyorak/api/review/domain/ReviewWaitingTime.java
+++ b/src/main/java/com/moyorak/api/review/domain/ReviewWaitingTime.java
@@ -1,0 +1,39 @@
+package com.moyorak.api.review.domain;
+
+import com.moyorak.infra.orm.AuditInformation;
+import com.moyorak.infra.orm.BooleanYnConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "review_waiting_time")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewWaitingTime extends AuditInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("웨이팅 시간")
+    @Column(name = "waiting_time", nullable = false, columnDefinition = "varchar(50)")
+    private String waitingTime;
+
+    @Comment("웨이팅 시간 값")
+    @Column(name = "waiting_time_value", nullable = false)
+    private Integer waitingTimeValue;
+
+    @Comment("사용 여부")
+    @Convert(converter = BooleanYnConverter.class)
+    @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
+    private boolean use = true;
+}

--- a/src/main/java/com/moyorak/api/review/dto/ReviewServingTimeResponse.java
+++ b/src/main/java/com/moyorak/api/review/dto/ReviewServingTimeResponse.java
@@ -1,0 +1,23 @@
+package com.moyorak.api.review.dto;
+
+import com.moyorak.api.review.domain.ReviewServingTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record ReviewServingTimeResponse(
+        @Schema(description = "서빙 시간 id", example = "3") Long servingTimeId,
+        @Schema(description = "서빙 시간", example = "10~15분 이내") String servingTime) {
+
+    public static ReviewServingTimeResponse from(ReviewServingTime reviewServingTime) {
+        return new ReviewServingTimeResponse(
+                reviewServingTime.getId(), reviewServingTime.getServingTime());
+    }
+
+    public static List<ReviewServingTimeResponse> fromList(
+            List<ReviewServingTime> reviewServingTimes) {
+        return reviewServingTimes.stream()
+                .map(ReviewServingTimeResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/moyorak/api/review/dto/ReviewWaitingTimeResponse.java
+++ b/src/main/java/com/moyorak/api/review/dto/ReviewWaitingTimeResponse.java
@@ -1,0 +1,23 @@
+package com.moyorak.api.review.dto;
+
+import com.moyorak.api.review.domain.ReviewWaitingTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record ReviewWaitingTimeResponse(
+        @Schema(description = "대기 시간 ID", example = "3") Long waitingTimeId,
+        @Schema(description = "대기 시간", example = "10~15분 이내") String waitingTime) {
+
+    public static ReviewWaitingTimeResponse from(ReviewWaitingTime reviewWaitingTime) {
+        return new ReviewWaitingTimeResponse(
+                reviewWaitingTime.getId(), reviewWaitingTime.getWaitingTime());
+    }
+
+    public static List<ReviewWaitingTimeResponse> fromList(
+            List<ReviewWaitingTime> reviewWaitingTimes) {
+        return reviewWaitingTimes.stream()
+                .map(ReviewWaitingTimeResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/moyorak/api/review/repository/ReviewServingTimeRepository.java
+++ b/src/main/java/com/moyorak/api/review/repository/ReviewServingTimeRepository.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.review.repository;
+
+import com.moyorak.api.review.domain.ReviewServingTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewServingTimeRepository extends JpaRepository<ReviewServingTime, Long> {
+    List<ReviewServingTime> findAllByUse(boolean use);
+}

--- a/src/main/java/com/moyorak/api/review/repository/ReviewWaitingTimeRepository.java
+++ b/src/main/java/com/moyorak/api/review/repository/ReviewWaitingTimeRepository.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.review.repository;
+
+import com.moyorak.api.review.domain.ReviewWaitingTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewWaitingTimeRepository extends JpaRepository<ReviewWaitingTime, Long> {
+    List<ReviewWaitingTime> findAllByUse(boolean use);
+}

--- a/src/main/java/com/moyorak/api/review/service/ReviewService.java
+++ b/src/main/java/com/moyorak/api/review/service/ReviewService.java
@@ -1,7 +1,15 @@
 package com.moyorak.api.review.service;
 
+import com.moyorak.api.review.domain.ReviewServingTime;
+import com.moyorak.api.review.domain.ReviewWaitingTime;
+import com.moyorak.api.review.dto.ReviewServingTimeResponse;
+import com.moyorak.api.review.dto.ReviewWaitingTimeResponse;
 import com.moyorak.api.review.dto.ReviewWithUserProjection;
 import com.moyorak.api.review.repository.ReviewRepository;
+import com.moyorak.api.review.repository.ReviewServingTimeRepository;
+import com.moyorak.api.review.repository.ReviewWaitingTimeRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,10 +20,32 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReviewService {
     private final ReviewRepository reviewRepository;
+    private final ReviewServingTimeRepository reviewServingTimeRepository;
+    private final ReviewWaitingTimeRepository reviewWaitingTimeRepository;
 
     @Transactional(readOnly = true)
     public Page<ReviewWithUserProjection> getReviewWithUserByTeamRestaurantId(
             Long teamRestaurantId, Pageable pageable) {
         return reviewRepository.findReviewWithUserByTeamRestaurantId(teamRestaurantId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReviewServingTimeResponse> getReviewServingTime() {
+        List<ReviewServingTime> reviewServingTimes = reviewServingTimeRepository.findAllByUse(true);
+        if (reviewServingTimes.isEmpty()) {
+            throw new BusinessException("서빙 시간 데이터가 없습니다.");
+        }
+
+        return ReviewServingTimeResponse.fromList(reviewServingTimes);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReviewWaitingTimeResponse> getReviewWaitingTime() {
+        List<ReviewWaitingTime> reviewWaitingTimes = reviewWaitingTimeRepository.findAllByUse(true);
+        if (reviewWaitingTimes.isEmpty()) {
+            throw new BusinessException("대기 시간 데이터가 없습니다.");
+        }
+
+        return ReviewWaitingTimeResponse.fromList(reviewWaitingTimes);
     }
 }

--- a/src/test/java/com/moyorak/api/review/domain/ReviewServingTimeFixture.java
+++ b/src/test/java/com/moyorak/api/review/domain/ReviewServingTimeFixture.java
@@ -1,0 +1,17 @@
+package com.moyorak.api.review.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ReviewServingTimeFixture {
+
+    public static ReviewServingTime fixture(
+            final Long id, final String servingTIme, final boolean ues) {
+        ReviewServingTime reviewServingTime = new ReviewServingTime();
+
+        ReflectionTestUtils.setField(reviewServingTime, "id", id);
+        ReflectionTestUtils.setField(reviewServingTime, "servingTime", servingTIme);
+        ReflectionTestUtils.setField(reviewServingTime, "use", ues);
+
+        return reviewServingTime;
+    }
+}

--- a/src/test/java/com/moyorak/api/review/domain/ReviewWaitingTimeFixture.java
+++ b/src/test/java/com/moyorak/api/review/domain/ReviewWaitingTimeFixture.java
@@ -1,0 +1,17 @@
+package com.moyorak.api.review.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ReviewWaitingTimeFixture {
+
+    public static ReviewWaitingTime fixture(
+            final Long id, final String waitingTime, final boolean ues) {
+        ReviewWaitingTime reviewWaitingTime = new ReviewWaitingTime();
+
+        ReflectionTestUtils.setField(reviewWaitingTime, "id", id);
+        ReflectionTestUtils.setField(reviewWaitingTime, "waitingTime", waitingTime);
+        ReflectionTestUtils.setField(reviewWaitingTime, "use", ues);
+
+        return reviewWaitingTime;
+    }
+}

--- a/src/test/java/com/moyorak/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/moyorak/api/review/service/ReviewServiceTest.java
@@ -1,13 +1,25 @@
 package com.moyorak.api.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
+import com.moyorak.api.review.domain.ReviewServingTime;
+import com.moyorak.api.review.domain.ReviewServingTimeFixture;
+import com.moyorak.api.review.domain.ReviewWaitingTime;
+import com.moyorak.api.review.domain.ReviewWaitingTimeFixture;
+import com.moyorak.api.review.dto.ReviewServingTimeResponse;
+import com.moyorak.api.review.dto.ReviewWaitingTimeResponse;
 import com.moyorak.api.review.dto.ReviewWithUserProjection;
 import com.moyorak.api.review.dto.ReviewWithUserProjectionFixture;
 import com.moyorak.api.review.repository.ReviewRepository;
+import com.moyorak.api.review.repository.ReviewServingTimeRepository;
+import com.moyorak.api.review.repository.ReviewWaitingTimeRepository;
+import com.moyorak.config.exception.BusinessException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +35,10 @@ public class ReviewServiceTest {
     @InjectMocks private ReviewService reviewService;
 
     @Mock private ReviewRepository reviewRepository;
+
+    @Mock private ReviewServingTimeRepository reviewServingTimeRepository;
+
+    @Mock private ReviewWaitingTimeRepository reviewWaitingTimeRepository;
 
     @Test
     @DisplayName("팀 레스토랑 ID로 리뷰와 사용자 정보를 조회한다")
@@ -47,5 +63,76 @@ public class ReviewServiceTest {
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().getFirst().name()).isEqualTo("아무개");
         assertThat(result.getContent().getFirst().extraText()).isEqualTo("좋은식당");
+    }
+
+    @Nested
+    @DisplayName("대기,서빙 시간 조회 시")
+    class GetReviewTimeList {
+        private final Long servingId = 1L;
+        private final Long waitingId = 2L;
+
+        @Test
+        @DisplayName("서빙 시간 데이터를 정상적으로 조회한다")
+        void getReviewServingTime_success() {
+            // given
+            final ReviewServingTime servingTime =
+                    ReviewServingTimeFixture.fixture(servingId, "10~15분", true);
+            given(reviewServingTimeRepository.findAllByUse(true)).willReturn(List.of(servingTime));
+
+            // when
+            final List<ReviewServingTimeResponse> result = reviewService.getReviewServingTime();
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(result).hasSize(1);
+                        it.assertThat(result.get(0).servingTimeId()).isEqualTo(1L);
+                        it.assertThat(result.get(0).servingTime()).isEqualTo("10~15분");
+                    });
+        }
+
+        @Test
+        @DisplayName("서빙 시간 데이터가 없으면 예외를 던진다")
+        void getReviewServingTime_noData_throwsException() {
+            // given
+            given(reviewServingTimeRepository.findAllByUse(true)).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getReviewServingTime())
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("서빙 시간 데이터가 없습니다.");
+        }
+
+        @Test
+        @DisplayName("대기 시간 데이터를 정상적으로 조회한다")
+        void getReviewWaitingTime_success() {
+            // given
+            final ReviewWaitingTime waitingTime =
+                    ReviewWaitingTimeFixture.fixture(waitingId, "10~15분", true);
+            given(reviewWaitingTimeRepository.findAllByUse(true)).willReturn(List.of(waitingTime));
+
+            // when
+            final List<ReviewWaitingTimeResponse> result = reviewService.getReviewWaitingTime();
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(result).hasSize(1);
+                        it.assertThat(result.get(0).waitingTimeId()).isEqualTo(2L);
+                        it.assertThat(result.get(0).waitingTime()).isEqualTo("10~15분");
+                    });
+        }
+
+        @Test
+        @DisplayName("대기 시간 데이터가 없으면 예외를 던진다")
+        void getReviewWaitingTime_noData_throwsException() {
+            // given
+            given(reviewWaitingTimeRepository.findAllByUse(true)).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getReviewWaitingTime())
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("대기 시간 데이터가 없습니다.");
+        }
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 리뷰 대기 시간 조회 기능 개발
- 리뷰 서빙 시간 조회 기능 개발

---

## 📝 코멘트
- 서빙 시간, 대기 시간 옵션을 내려주기 위한 API
-  `Review` 의 대기시간, 서빙 시간에 대한 값을 , `ReviewServingTime` `ReviewWaitingTime` 의 Integer 값(servingTimeValue, waitingTimeValue) 으로 넣으려고 합니다.  `TeamRestaurant` 의 평균값은 리뷰들의  Integer 값 을 평균내고, 해당 값 과 가장 가까운 값으로 조회 되는 `ReviewServingTime` `ReviewWaitingTime` 들의 `servingTime` `waitingTime` 값을 내려 주려 합니다. 이에 대해 어떻게 생각하시는지 의견 주시면 감사하겠습니다.