### PR TITLE
feat: #189 팀 멤버 역할 변경 기능

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
@@ -1,11 +1,14 @@
 package com.moyorak.api.team.controller;
 
 import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.team.dto.TeamUserRoleUpdateRequest;
 import com.moyorak.api.team.service.TeamJoinFacade;
+import com.moyorak.api.team.service.TeamUserManagementService;
 import com.moyorak.api.team.service.TeamUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,6 +31,7 @@ class TeamUserController {
 
     private final TeamUserService teamUserService;
     private final TeamJoinFacade teamJoinFacade;
+    private final TeamUserManagementService teamUserManagementService;
 
     @DeleteMapping("/teams/{teamId}/team-members/me")
     @Operation(summary = "팀 탈퇴", description = "팀을 탈퇴합니다.")
@@ -51,5 +56,16 @@ class TeamUserController {
             @PathVariable @Positive final Long teamMemberId,
             @AuthenticationPrincipal final UserPrincipal userPrincipal) {
         teamUserService.approveRequestJoin(userPrincipal.getId(), teamId, teamMemberId);
+    }
+
+    @PutMapping("/teams/{teamId}/team-members/{teamMemberId}/role")
+    @Operation(summary = "팀 멤버 역할 변경", description = "팀 멤버 역할을 변경합니다.")
+    public void updateRole(
+            @PathVariable @Positive final Long teamId,
+            @PathVariable @Positive final Long teamMemberId,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal,
+            @Valid @RequestBody final TeamUserRoleUpdateRequest request) {
+        teamUserManagementService.updateRole(
+                userPrincipal.getId(), teamId, teamMemberId, request.role());
     }
 }

--- a/src/main/java/com/moyorak/api/team/domain/NotTeamAdminException.java
+++ b/src/main/java/com/moyorak/api/team/domain/NotTeamAdminException.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.team.domain;
+
+import com.moyorak.config.exception.BusinessException;
+
+public class NotTeamAdminException extends BusinessException {
+    public NotTeamAdminException() {
+        super("팀 관리자가 아닙니다.");
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/NotTeamUserException.java
+++ b/src/main/java/com/moyorak/api/team/domain/NotTeamUserException.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.team.domain;
+
+import com.moyorak.config.exception.BusinessException;
+
+public class NotTeamUserException extends BusinessException {
+    public NotTeamUserException() {
+        super("해당 팀의 팀원이 아닙니다.");
+    }
+}

--- a/src/main/java/com/moyorak/api/team/domain/TeamUser.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamUser.java
@@ -81,6 +81,10 @@ public class TeamUser extends AuditInformation {
         use = false;
     }
 
+    public void updateRole(TeamRole role) {
+        this.role = role;
+    }
+
     public static TeamUser create(
             Team team, Long userId, TeamRole teamRole, TeamUserStatus teamUserStatus) {
         TeamUser teamUser = new TeamUser();

--- a/src/main/java/com/moyorak/api/team/dto/TeamUserRoleUpdateRequest.java
+++ b/src/main/java/com/moyorak/api/team/dto/TeamUserRoleUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.moyorak.api.team.dto;
+
+import com.moyorak.api.team.domain.TeamRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(title = "[팀 멤버] 팀 멤버 역할 변경 요청 DTO")
+public record TeamUserRoleUpdateRequest(
+        @NotNull(message = "변경할 역할을 입력해주세요.")
+                @Schema(description = "변경할 팀 역할", example = "TEAM_ADMIN")
+                TeamRole role) {}

--- a/src/main/java/com/moyorak/api/team/service/TeamUserManagementService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamUserManagementService.java
@@ -1,0 +1,49 @@
+package com.moyorak.api.team.service;
+
+import com.moyorak.api.team.domain.NotTeamAdminException;
+import com.moyorak.api.team.domain.NotTeamUserException;
+import com.moyorak.api.team.domain.TeamRole;
+import com.moyorak.api.team.domain.TeamUser;
+import com.moyorak.api.team.domain.TeamUserNotFoundException;
+import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.repository.TeamUserRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamUserManagementService {
+
+    private final TeamUserRepository teamUserRepository;
+
+    @Transactional
+    public void updateRole(
+            final Long userId, final Long teamId, final Long teamUserId, final TeamRole role) {
+        final TeamUser teamUserAdmin =
+                teamUserRepository
+                        .findByUserIdAndTeamIdAndUse(userId, teamId, true)
+                        .orElseThrow(TeamUserNotFoundException::new);
+
+        if (!teamUserAdmin.isTeamAdmin()) {
+            throw new NotTeamAdminException();
+        }
+
+        if (Objects.equals(teamUserAdmin.getId(), teamUserId)) {
+            throw new BusinessException("본인은 변경이 불가능합니다.");
+        }
+
+        final TeamUser teamUser =
+                teamUserRepository
+                        .findByIdAndUseAndStatus(teamUserId, true, TeamUserStatus.APPROVED)
+                        .orElseThrow(TeamUserNotFoundException::new);
+
+        if (!teamUser.isTeam(teamId)) {
+            throw new NotTeamUserException();
+        }
+
+        teamUser.updateRole(role);
+    }
+}

--- a/src/test/java/com/moyorak/api/team/domain/TeamFixture.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamFixture.java
@@ -14,4 +14,13 @@ public class TeamFixture {
 
         return team;
     }
+
+    public static Team fixture(final Long id, final boolean ues) {
+        Team team = new Team();
+
+        ReflectionTestUtils.setField(team, "id", id);
+        ReflectionTestUtils.setField(team, "use", ues);
+
+        return team;
+    }
 }

--- a/src/test/java/com/moyorak/api/team/domain/TeamUserFixture.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamUserFixture.java
@@ -8,7 +8,7 @@ public class TeamUserFixture {
             final Long userId, final Team team, final TeamUserStatus status, boolean use) {
         TeamUser teamUser = new TeamUser();
 
-        ReflectionTestUtils.setField(teamUser, "id", userId);
+        ReflectionTestUtils.setField(teamUser, "userId", userId);
         ReflectionTestUtils.setField(teamUser, "team", team);
         ReflectionTestUtils.setField(teamUser, "status", status);
         ReflectionTestUtils.setField(teamUser, "use", use);
@@ -28,5 +28,24 @@ public class TeamUserFixture {
 
     public static TeamUser fixtureApproved(final Long userId, final Team team) {
         return fixture(userId, team, TeamUserStatus.APPROVED, true);
+    }
+
+    public static TeamUser fixture(
+            final Long id,
+            final Team team,
+            final Long userId,
+            final TeamUserStatus status,
+            final TeamRole role,
+            final boolean use) {
+        TeamUser teamUser = new TeamUser();
+
+        ReflectionTestUtils.setField(teamUser, "id", id);
+        ReflectionTestUtils.setField(teamUser, "team", team);
+        ReflectionTestUtils.setField(teamUser, "status", status);
+        ReflectionTestUtils.setField(teamUser, "role", role);
+        ReflectionTestUtils.setField(teamUser, "use", use);
+        ReflectionTestUtils.setField(teamUser, "userId", userId);
+
+        return teamUser;
     }
 }

--- a/src/test/java/com/moyorak/api/team/service/TeamUserManagementServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamUserManagementServiceTest.java
@@ -1,0 +1,185 @@
+package com.moyorak.api.team.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.moyorak.api.team.domain.NotTeamAdminException;
+import com.moyorak.api.team.domain.NotTeamUserException;
+import com.moyorak.api.team.domain.Team;
+import com.moyorak.api.team.domain.TeamFixture;
+import com.moyorak.api.team.domain.TeamRole;
+import com.moyorak.api.team.domain.TeamUser;
+import com.moyorak.api.team.domain.TeamUserFixture;
+import com.moyorak.api.team.domain.TeamUserNotFoundException;
+import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.repository.TeamUserRepository;
+import com.moyorak.config.exception.BusinessException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TeamUserManagementServiceTest {
+
+    @InjectMocks private TeamUserManagementService teamUserManagementService;
+
+    @Mock private TeamUserRepository teamUserRepository;
+
+    @Nested
+    @DisplayName("역할 변경 시")
+    class UpdateRole {
+
+        final Long teamId = 1L;
+        final Long requesterUserId = 1L;
+        final Long teamUserAdminId = 1L;
+        final Long targetTeamUserId = 2L;
+
+        @Test
+        @DisplayName("요청자가 팀 유저가 아닌 경우 TeamUserNotFoundException이 발생한다")
+        void isNotTeamUser() {
+            // given
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(requesterUserId, teamId, true))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.updateRole(
+                                            requesterUserId,
+                                            teamId,
+                                            targetTeamUserId,
+                                            TeamRole.TEAM_ADMIN))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("요청자가 관리자가 아닌 경우 NotTeamAdminException이 발생한다")
+        void isNotAdmin() {
+            // given
+            final TeamUser nonAdmin =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(requesterUserId, teamId, true))
+                    .willReturn(Optional.of(nonAdmin));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.updateRole(
+                                            requesterUserId,
+                                            teamId,
+                                            targetTeamUserId,
+                                            TeamRole.TEAM_ADMIN))
+                    .isInstanceOf(NotTeamAdminException.class)
+                    .hasMessage("팀 관리자가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("본인을 변경하려는 경우 BusinessException이 발생한다")
+        void changeSelfRole() {
+            // given
+            final Team team = TeamFixture.fixture(teamId, true);
+            final TeamUser adminUser =
+                    TeamUserFixture.fixture(
+                            teamUserAdminId,
+                            team,
+                            requesterUserId,
+                            TeamUserStatus.APPROVED,
+                            TeamRole.TEAM_ADMIN,
+                            true);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(requesterUserId, teamId, true))
+                    .willReturn(Optional.of(adminUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.updateRole(
+                                            requesterUserId,
+                                            teamId,
+                                            adminUser.getId(),
+                                            TeamRole.TEAM_ADMIN))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("본인은 변경이 불가능합니다.");
+        }
+
+        @Test
+        @DisplayName("변경 대상이 승인 상태 유저가 아닌 경우 TeamUserNotFoundException이 발생한다")
+        void targetUserNotFound() {
+            // given
+            final Team team = TeamFixture.fixture(teamId, true);
+            final TeamUser adminUser =
+                    TeamUserFixture.fixture(
+                            teamUserAdminId,
+                            team,
+                            requesterUserId,
+                            TeamUserStatus.APPROVED,
+                            TeamRole.TEAM_ADMIN,
+                            true);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(requesterUserId, teamId, true))
+                    .willReturn(Optional.of(adminUser));
+            given(
+                            teamUserRepository.findByIdAndUseAndStatus(
+                                    targetTeamUserId, true, TeamUserStatus.APPROVED))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.updateRole(
+                                            requesterUserId,
+                                            teamId,
+                                            targetTeamUserId,
+                                            TeamRole.TEAM_MEMBER))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("변경 대상이 다른 팀에 속한 경우 NotTeamUserException이 발생한다")
+        void isNotSameTeam() {
+            // given
+            final Team team = TeamFixture.fixture(teamId, true);
+            final TeamUser adminUser =
+                    TeamUserFixture.fixture(
+                            teamUserAdminId,
+                            team,
+                            requesterUserId,
+                            TeamUserStatus.APPROVED,
+                            TeamRole.TEAM_ADMIN,
+                            true);
+
+            final Team otherTeam = TeamFixture.fixture(999L, true);
+            final TeamUser otherTeamUser =
+                    TeamUserFixture.fixture(
+                            targetTeamUserId,
+                            otherTeam,
+                            2L,
+                            TeamUserStatus.APPROVED,
+                            TeamRole.TEAM_ADMIN,
+                            true);
+
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(requesterUserId, teamId, true))
+                    .willReturn(Optional.of(adminUser));
+            given(
+                            teamUserRepository.findByIdAndUseAndStatus(
+                                    targetTeamUserId, true, TeamUserStatus.APPROVED))
+                    .willReturn(Optional.of(otherTeamUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.updateRole(
+                                            requesterUserId,
+                                            teamId,
+                                            targetTeamUserId,
+                                            TeamRole.TEAM_MEMBER))
+                    .isInstanceOf(NotTeamUserException.class)
+                    .hasMessage("해당 팀의 팀원이 아닙니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팀 멤버 역할 변경 기능 개발

---

## 📝 코멘트
팀 관리 서비스(`TeamUserManagementService`)로 개발했습니다.
팀원을 관리하는 서비스로 따로 빼는게 더 좋을 것 같아서 이와 같이 개발했습니다. (팀원 관리 관심사를 응집)
`TeamUserManagementService`(팀원 관리 서비스) - 팀원 거절, 승인, 팀원 역할 변경, 관리용 팀원들 조회, 강퇴 등
`TeamUserService`(팀유저 일반전인 서비스) - 가입 요청, 탈퇴, 팀원 전용 팀원들 조회, 팀원인지 확인 조회 등

만약에 이 방법으로 가는 것으로 동의하시면 제가 리팩토링 진행하고,
현상 유지로 의견주시면 다시 반영하겠습니다.