### PR TITLE
refactor: #194 팀 유저 관리 서비스로 리팩토링

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
@@ -51,7 +51,7 @@ class TeamUserController {
             @PathVariable @Positive final Long teamId,
             @AuthenticationPrincipal final UserPrincipal userPrincipal,
             @Valid final TeamUserListRequest request) {
-        return teamUserService.getTeamUsers(userPrincipal.getId(), teamId, request);
+        return teamUserManagementService.getTeamUsers(userPrincipal.getId(), teamId, request);
     }
 
     @PostMapping("/teams/{teamId}/team-members")
@@ -68,7 +68,7 @@ class TeamUserController {
             @PathVariable @Positive final Long teamId,
             @PathVariable @Positive final Long teamMemberId,
             @AuthenticationPrincipal final UserPrincipal userPrincipal) {
-        teamUserService.approveRequestJoin(userPrincipal.getId(), teamId, teamMemberId);
+        teamUserManagementService.approveRequestJoin(userPrincipal.getId(), teamId, teamMemberId);
     }
 
     @PutMapping("/teams/{teamId}/team-members/{teamMemberId}/role")

--- a/src/main/java/com/moyorak/api/team/service/TeamUserManagementService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamUserManagementService.java
@@ -6,10 +6,14 @@ import com.moyorak.api.team.domain.TeamRole;
 import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.dto.TeamUserListRequest;
+import com.moyorak.api.team.dto.TeamUserResponse;
 import com.moyorak.api.team.repository.TeamUserRepository;
 import com.moyorak.config.exception.BusinessException;
+import com.moyorak.global.domain.ListResponse;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,14 +26,9 @@ public class TeamUserManagementService {
     @Transactional
     public void updateRole(
             final Long userId, final Long teamId, final Long teamUserId, final TeamRole role) {
-        final TeamUser teamUserAdmin =
-                teamUserRepository
-                        .findByUserIdAndTeamIdAndUse(userId, teamId, true)
-                        .orElseThrow(TeamUserNotFoundException::new);
+        final TeamUser teamUserAdmin = getTeamUser(userId, teamId);
 
-        if (!teamUserAdmin.isTeamAdmin()) {
-            throw new NotTeamAdminException();
-        }
+        validateApprovedTeamUserAdmin(teamUserAdmin);
 
         if (Objects.equals(teamUserAdmin.getId(), teamUserId)) {
             throw new BusinessException("본인은 변경이 불가능합니다.");
@@ -45,5 +44,54 @@ public class TeamUserManagementService {
         }
 
         teamUser.changeRole(role);
+    }
+
+    @Transactional(readOnly = true)
+    public ListResponse<TeamUserResponse> getTeamUsers(
+            final Long userId, final Long teamId, final TeamUserListRequest request) {
+
+        TeamUser teamUserAdmin = getTeamUser(userId, teamId);
+
+        validateApprovedTeamUserAdmin(teamUserAdmin);
+
+        final Page<TeamUserResponse> teamUsers =
+                teamUserRepository.findByConditions(
+                        teamId, request.getStatus(), true, request.toRecentPageable());
+
+        return ListResponse.from(teamUsers);
+    }
+
+    @Transactional
+    public void approveRequestJoin(final Long userId, final Long teamId, final Long teamMemberId) {
+
+        TeamUser teamUserAdmin = getTeamUser(userId, teamId);
+
+        validateApprovedTeamUserAdmin(teamUserAdmin);
+
+        final TeamUser teamUser =
+                teamUserRepository
+                        .findByIdAndUseAndStatus(teamMemberId, true, TeamUserStatus.PENDING)
+                        .orElseThrow(TeamUserNotFoundException::new);
+        if (!teamUser.isTeam(teamId)) {
+            throw new BusinessException("해당 팀의 팀원이 아닙니다.");
+        }
+
+        teamUser.changeStatus(TeamUserStatus.APPROVED);
+    }
+
+    private TeamUser getTeamUser(final Long userId, final Long teamId) {
+        return teamUserRepository
+                .findByUserIdAndTeamIdAndUse(userId, teamId, true)
+                .orElseThrow(TeamUserNotFoundException::new);
+    }
+
+    private void validateApprovedTeamUserAdmin(final TeamUser teamUserAdmin) {
+        if (teamUserAdmin.isNotApproved()) {
+            throw new TeamUserNotFoundException();
+        }
+
+        if (!teamUserAdmin.isTeamAdmin()) {
+            throw new NotTeamAdminException();
+        }
     }
 }

--- a/src/test/java/com/moyorak/api/team/service/TeamUserManagementServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamUserManagementServiceTest.java
@@ -1,8 +1,11 @@
 package com.moyorak.api.team.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.moyorak.api.company.domain.Company;
+import com.moyorak.api.company.domain.CompanyFixture;
 import com.moyorak.api.team.domain.NotTeamAdminException;
 import com.moyorak.api.team.domain.NotTeamUserException;
 import com.moyorak.api.team.domain.Team;
@@ -12,6 +15,8 @@ import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserFixture;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.domain.TeamUserStatus;
+import com.moyorak.api.team.dto.TeamUserListRequest;
+import com.moyorak.api.team.dto.TeamUserListRequestFixture;
 import com.moyorak.api.team.repository.TeamUserRepository;
 import com.moyorak.config.exception.BusinessException;
 import java.util.Optional;
@@ -180,6 +185,147 @@ class TeamUserManagementServiceTest {
                                             TeamRole.TEAM_MEMBER))
                     .isInstanceOf(NotTeamUserException.class)
                     .hasMessage("해당 팀의 팀원이 아닙니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("getTeamUsers 호출 시")
+    class GetTeamUsers {
+
+        final Long teamId = 1L;
+        final Long userId = 1L;
+
+        @Test
+        @DisplayName("팀 유저가 존재하지 않으면 TeamUserNotFoundException이 발생한다.")
+        void isNotExist() {
+            // given
+            final TeamUserListRequest request =
+                    TeamUserListRequestFixture.fixture(TeamUserStatus.APPROVED, 10, 1);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () -> teamUserManagementService.getTeamUsers(userId, teamId, request))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("팀 유저가 가입 상태가 아니면 TeamUserNotFoundException이 발생한다.")
+        void isNotApproved() {
+            // given
+            final TeamUser notApprovedUser =
+                    TeamUserFixture.fixture(TeamUserStatus.PENDING, TeamRole.TEAM_MEMBER, true);
+            final TeamUserListRequest request =
+                    TeamUserListRequestFixture.fixture(TeamUserStatus.APPROVED, 10, 1);
+
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
+                    .willReturn(Optional.of(notApprovedUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () -> teamUserManagementService.getTeamUsers(userId, teamId, request))
+                    .isInstanceOf(TeamUserNotFoundException.class)
+                    .hasMessage("팀 멤버가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("팀 관리자가 아닌 경우 BusinessException이 발생한다.")
+        void isNotAdmin() {
+            // given
+            final TeamUser normalUser =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
+            final TeamUserListRequest request =
+                    TeamUserListRequestFixture.fixture(
+                            TeamUserStatus.APPROVED, 10, 1); // 가입 아닌 상태 조회 시도
+
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
+                    .willReturn(Optional.of(normalUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () -> teamUserManagementService.getTeamUsers(userId, teamId, request))
+                    .isInstanceOf(NotTeamAdminException.class)
+                    .hasMessage("팀 관리자가 아닙니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("가입 신청 승인 시")
+    class ApproveRequestJoin {
+
+        final Long teamId = 200L;
+        final Long otherTeamId = 300L;
+        final Long adminUserId = 10L;
+        final Long pendingMemberId = 20L;
+        final Company company = CompanyFixture.fixture(1L, "우가우가", 37.5, 36.5, true);
+        final Team team = TeamFixture.fixture(teamId, company, true);
+        final Team otherTeam = TeamFixture.fixture(otherTeamId, company, true);
+
+        @Test
+        @DisplayName("승인자가 팀 관리자가 아니면 예외를 발생시킨다")
+        void notAdminUser() {
+            // given
+            final TeamUser nonAdminUser =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(adminUserId, teamId, true))
+                    .willReturn(Optional.of(nonAdminUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.approveRequestJoin(
+                                            adminUserId, teamId, pendingMemberId))
+                    .isInstanceOf(NotTeamAdminException.class)
+                    .hasMessage("팀 관리자가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("요청자가 팀원이 아니면 예외를 발생시킨다")
+        void notSameTeam() {
+            // given
+            final TeamUser adminUser =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
+            final TeamUser otherTeamUser =
+                    TeamUserFixture.fixture(
+                            pendingMemberId, otherTeam, TeamUserStatus.PENDING, true);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(adminUserId, teamId, true))
+                    .willReturn(Optional.of(adminUser));
+            given(
+                            teamUserRepository.findByIdAndUseAndStatus(
+                                    pendingMemberId, true, TeamUserStatus.PENDING))
+                    .willReturn(Optional.of(otherTeamUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    teamUserManagementService.approveRequestJoin(
+                                            adminUserId, teamId, pendingMemberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("해당 팀의 팀원이 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("승인이 정상적으로 처리된다")
+        void success() {
+            // given
+            final TeamUser adminUser =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
+            final TeamUser pendingUser =
+                    TeamUserFixture.fixture(pendingMemberId, team, TeamUserStatus.PENDING, true);
+            given(teamUserRepository.findByUserIdAndTeamIdAndUse(adminUserId, teamId, true))
+                    .willReturn(Optional.of(adminUser));
+            given(
+                            teamUserRepository.findByIdAndUseAndStatus(
+                                    pendingMemberId, true, TeamUserStatus.PENDING))
+                    .willReturn(Optional.of(pendingUser));
+
+            // when
+            teamUserManagementService.approveRequestJoin(adminUserId, teamId, pendingMemberId);
+
+            // then
+            assertThat(pendingUser.getStatus()).isEqualTo(TeamUserStatus.APPROVED);
         }
     }
 }

--- a/src/test/java/com/moyorak/api/team/service/TeamUserServiceTest.java
+++ b/src/test/java/com/moyorak/api/team/service/TeamUserServiceTest.java
@@ -17,8 +17,6 @@ import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserFixture;
 import com.moyorak.api.team.domain.TeamUserNotFoundException;
 import com.moyorak.api.team.domain.TeamUserStatus;
-import com.moyorak.api.team.dto.TeamUserListRequest;
-import com.moyorak.api.team.dto.TeamUserListRequestFixture;
 import com.moyorak.api.team.repository.TeamUserRepository;
 import com.moyorak.config.exception.BusinessException;
 import java.util.Optional;
@@ -91,66 +89,6 @@ class TeamUserServiceTest {
     }
 
     @Nested
-    @DisplayName("getTeamUsers 호출 시")
-    class GetTeamUsers {
-
-        final Long teamId = 1L;
-        final Long userId = 1L;
-
-        @Test
-        @DisplayName("팀 유저가 존재하지 않으면 TeamUserNotFoundException이 발생한다.")
-        void isNotExist() {
-            // given
-            final TeamUserListRequest request =
-                    TeamUserListRequestFixture.fixture(TeamUserStatus.APPROVED, 10, 1);
-            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> teamUserService.getTeamUsers(userId, teamId, request))
-                    .isInstanceOf(TeamUserNotFoundException.class)
-                    .hasMessage("팀 멤버가 아닙니다.");
-        }
-
-        @Test
-        @DisplayName("팀 유저가 가입 상태가 아니면 TeamUserNotFoundException이 발생한다.")
-        void isNotApproved() {
-            // given
-            final TeamUser notApprovedUser =
-                    TeamUserFixture.fixture(TeamUserStatus.PENDING, TeamRole.TEAM_MEMBER, true);
-            final TeamUserListRequest request =
-                    TeamUserListRequestFixture.fixture(TeamUserStatus.APPROVED, 10, 1);
-
-            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
-                    .willReturn(Optional.of(notApprovedUser));
-
-            // when & then
-            assertThatThrownBy(() -> teamUserService.getTeamUsers(userId, teamId, request))
-                    .isInstanceOf(TeamUserNotFoundException.class)
-                    .hasMessage("팀 멤버가 아닙니다.");
-        }
-
-        @Test
-        @DisplayName("팀 관리자가 아닌 경우 BusinessException이 발생한다.")
-        void isNotAdmin() {
-            // given
-            final TeamUser normalUser =
-                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
-            final TeamUserListRequest request =
-                    TeamUserListRequestFixture.fixture(
-                            TeamUserStatus.APPROVED, 10, 1); // 가입 아닌 상태 조회 시도
-
-            given(teamUserRepository.findByUserIdAndTeamIdAndUse(userId, teamId, true))
-                    .willReturn(Optional.of(normalUser));
-
-            // when & then
-            assertThatThrownBy(() -> teamUserService.getTeamUsers(userId, teamId, request))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("팀 관리자만 조회할 수 있습니다.");
-        }
-    }
-
-    @Nested
     @DisplayName("가입 승인 신청 시")
     class RequestJoin {
 
@@ -197,84 +135,6 @@ class TeamUserServiceTest {
                                                     && user.getTeam().equals(team)
                                                     && user.getRole() == TeamRole.TEAM_MEMBER
                                                     && user.getStatus() == TeamUserStatus.PENDING));
-        }
-    }
-
-    @Nested
-    @DisplayName("가입 신청 승인 시")
-    class ApproveRequestJoin {
-
-        final Long teamId = 200L;
-        final Long otherTeamId = 300L;
-        final Long adminUserId = 10L;
-        final Long pendingMemberId = 20L;
-        final Company company = CompanyFixture.fixture(1L, "우가우가", 37.5, 36.5, true);
-        final Team team = TeamFixture.fixture(teamId, company, true);
-        final Team otherTeam = TeamFixture.fixture(otherTeamId, company, true);
-
-        @Test
-        @DisplayName("승인자가 팀 관리자가 아니면 예외를 발생시킨다")
-        void notAdminUser() {
-            // given
-            final TeamUser nonAdminUser =
-                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_MEMBER, true);
-            given(teamUserRepository.findByUserIdAndTeamIdAndUse(adminUserId, teamId, true))
-                    .willReturn(Optional.of(nonAdminUser));
-
-            // when & then
-            assertThatThrownBy(
-                            () ->
-                                    teamUserService.approveRequestJoin(
-                                            adminUserId, teamId, pendingMemberId))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("승인을 하는 주체가, 팀 관리자가 아닙니다.");
-        }
-
-        @Test
-        @DisplayName("요청자가 팀원이 아니면 예외를 발생시킨다")
-        void notSameTeam() {
-            // given
-            final TeamUser adminUser =
-                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
-            final TeamUser otherTeamUser =
-                    TeamUserFixture.fixture(
-                            pendingMemberId, otherTeam, TeamUserStatus.PENDING, true);
-            given(teamUserRepository.findByUserIdAndTeamIdAndUse(adminUserId, teamId, true))
-                    .willReturn(Optional.of(adminUser));
-            given(
-                            teamUserRepository.findByIdAndUseAndStatus(
-                                    pendingMemberId, true, TeamUserStatus.PENDING))
-                    .willReturn(Optional.of(otherTeamUser));
-
-            // when & then
-            assertThatThrownBy(
-                            () ->
-                                    teamUserService.approveRequestJoin(
-                                            adminUserId, teamId, pendingMemberId))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage("해당 팀의 팀원이 아닙니다.");
-        }
-
-        @Test
-        @DisplayName("승인이 정상적으로 처리된다")
-        void success() {
-            // given
-            final TeamUser adminUser =
-                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
-            final TeamUser pendingUser =
-                    TeamUserFixture.fixture(pendingMemberId, team, TeamUserStatus.PENDING, true);
-            given(teamUserRepository.findByUserIdAndTeamIdAndUse(adminUserId, teamId, true))
-                    .willReturn(Optional.of(adminUser));
-            given(
-                            teamUserRepository.findByIdAndUseAndStatus(
-                                    pendingMemberId, true, TeamUserStatus.PENDING))
-                    .willReturn(Optional.of(pendingUser));
-
-            // when
-            teamUserService.approveRequestJoin(adminUserId, teamId, pendingMemberId);
-
-            // then
-            assertThat(pendingUser.getStatus()).isEqualTo(TeamUserStatus.APPROVED);
         }
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팀 유저 관리관련된 로직을 `TeamUserManagementService`으로 리팩토링

---

## 📝 코멘트
- 서비스 객체 리팩토링
- `TeamUserManagementService` 내부에서 **getTeamUser**(`TeamUser` 조회 메서드)와 **validateApprovedTeamUserAdmin**(관리자 검증 메서드)로 리팩토링 후 재사용


