### PR TITLE
feat: #127 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/moyorak/api/auth/controller/UserController.java
+++ b/src/main/java/com/moyorak/api/auth/controller/UserController.java
@@ -1,12 +1,19 @@
 package com.moyorak.api.auth.controller;
 
+import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.dto.SignUpRequest;
 import com.moyorak.api.auth.dto.SignUpResponse;
+import com.moyorak.api.auth.service.UserFacade;
 import com.moyorak.api.auth.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,11 +25,31 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "[회원] 회원 관리 API", description = "회원에 관한 정보를 관리합니다.")
 class UserController {
 
+    private final UserFacade userFacade;
+
     private final UserService userService;
 
     @PostMapping("/sign-up")
     @Operation(summary = "[회원] 회원 가입", description = "회원 가입을 요청합니다.")
     public SignUpResponse signUp(@RequestBody @Valid final SignUpRequest request) {
         return userService.signUp(request);
+    }
+
+    @SecurityRequirement(name = "JWT")
+    @DeleteMapping("/unregister")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+                @ApiResponse(
+                        responseCode = "400",
+                        description =
+                                "<ol><li>팀에 관리자로 속해 있는 경우</li><li>회원 정보가 없는 경우</li><li>로그인 정보가 없는 경우</li><li>예상치 못한 클라이언트 오류</li></ol>"),
+                @ApiResponse(responseCode = "500", description = "예상치 못한 서버 오류"),
+            })
+    @Operation(
+            summary = "[회원] 회원 탈퇴",
+            description = "회원 탈퇴를 요청합니다.\n이름과 생년월일, 성별, 알러지 + 비선호 음식, 회사, 팀 정보가 제거 됩니다.")
+    public void unregister(@AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        userFacade.unregister(userPrincipal.getId());
     }
 }

--- a/src/main/java/com/moyorak/api/auth/domain/Gender.java
+++ b/src/main/java/com/moyorak/api/auth/domain/Gender.java
@@ -5,7 +5,8 @@ import org.springframework.util.StringUtils;
 
 public enum Gender {
     MALE,
-    FEMALE;
+    FEMALE,
+    UNREGISTER;
 
     @JsonCreator
     public static Gender from(final String input) {

--- a/src/main/java/com/moyorak/api/auth/domain/User.java
+++ b/src/main/java/com/moyorak/api/auth/domain/User.java
@@ -43,7 +43,7 @@ public class User extends AuditInformation {
     @NotNull
     @Comment("성별")
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "gender", nullable = false, columnDefinition = "varchar(6)")
+    @Column(name = "gender", nullable = false, columnDefinition = "varchar(10)")
     private Gender gender;
 
     @NotNull
@@ -51,9 +51,8 @@ public class User extends AuditInformation {
     @Column(name = "birthday", nullable = false, columnDefinition = "date")
     private LocalDate birthday;
 
-    @NotNull
     @Comment("프로필 이미지 URL")
-    @Column(name = "profile_image", nullable = false, columnDefinition = "varchar(256)")
+    @Column(name = "profile_image", columnDefinition = "varchar(256)")
     private String profileImage;
 
     @NotNull
@@ -91,5 +90,16 @@ public class User extends AuditInformation {
                 .birthday(birthday)
                 .profileImage(profileImage)
                 .build();
+    }
+
+    /** 회원 탈퇴 */
+    public void unregister() {
+        this.email = "UNREGISTER";
+        this.name = "UNREGISTER";
+        this.gender = Gender.UNREGISTER;
+        this.birthday = LocalDate.of(9999, 12, 31);
+        this.profileImage = null;
+
+        this.use = false;
     }
 }

--- a/src/main/java/com/moyorak/api/auth/domain/UserToken.java
+++ b/src/main/java/com/moyorak/api/auth/domain/UserToken.java
@@ -51,8 +51,13 @@ public class UserToken extends AuditInformation {
         return !StringUtils.hasText(this.accessToken);
     }
 
+    /**
+     * 등록 된 토큰을 초기화합니다. <br>
+     * 로그아웃 혹은 탈퇴때 사용됩니다.
+     */
     public void clear() {
         this.accessToken = null;
+        this.refreshToken = null;
     }
 
     public boolean isEqualsToken(final String token) {

--- a/src/main/java/com/moyorak/api/auth/repository/MealTagRepository.java
+++ b/src/main/java/com/moyorak/api/auth/repository/MealTagRepository.java
@@ -4,6 +4,7 @@ import com.moyorak.api.auth.domain.MealTag;
 import com.moyorak.api.auth.dto.MealTagTypeCount;
 import jakarta.persistence.QueryHint;
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
@@ -13,12 +14,12 @@ public interface MealTagRepository extends CrudRepository<MealTag, Long> {
 
     @Query(
             """
-            SELECT new com.moyorak.api.auth.dto.MealTagTypeCount(f.type, COUNT(f))
-            FROM MealTag f
-            WHERE f.userId = :userId
-            AND f.use = true
-            GROUP BY f.type
-        """)
+                SELECT new com.moyorak.api.auth.dto.MealTagTypeCount(f.type, COUNT(f))
+                FROM MealTag f
+                WHERE f.userId = :userId
+                AND f.use = true
+                GROUP BY f.type
+            """)
     @QueryHints(
             @QueryHint(
                     name = "org.hibernate.comment",
@@ -31,4 +32,18 @@ public interface MealTagRepository extends CrudRepository<MealTag, Long> {
                     name = "org.hibernate.comment",
                     value = "FoodFlagRepository.findByUserIdAndUse : 회원 ID별 등록된 항목을 조회합니다."))
     List<MealTag> findByUserIdAndUse(Long userId, boolean use);
+
+    @Modifying
+    @Query(
+            """
+            UPDATE MealTag mt
+            SET mt.userId = null,
+                mt.use = false
+            WHERE mt.userId = :userId
+        """)
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "FoodFlagRepository.clearByUserId : 회원 ID별 등록된 항목을 조회합니다."))
+    void clearByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/moyorak/api/auth/repository/UserRepository.java
+++ b/src/main/java/com/moyorak/api/auth/repository/UserRepository.java
@@ -13,4 +13,10 @@ public interface UserRepository extends CrudRepository<User, Long> {
                     name = "org.hibernate.comment",
                     value = "UserRepository.findByEmail : 이메일로 회원 정보를 조회합니다."))
     Optional<User> findByEmailAndUse(String email, Boolean isUse);
+
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "UserRepository.findByIdAndUse : 회원 고유 ID와 활성 여부로 회원 정보를 조회합니다."))
+    Optional<User> findByIdAndUse(Long id, Boolean isUse);
 }

--- a/src/main/java/com/moyorak/api/auth/service/AuthService.java
+++ b/src/main/java/com/moyorak/api/auth/service/AuthService.java
@@ -41,6 +41,12 @@ public class AuthService {
         return new SignInResponse(token, refreshToken);
     }
 
+    /**
+     * 로그아웃을 요청합니다. <br>
+     * 토큰 정보를 초기화합니다.
+     *
+     * @param userId 회원 고유 ID
+     */
     @Transactional
     public void signOut(final Long userId) {
         UserToken userToken = getUserLastToken(userId);

--- a/src/main/java/com/moyorak/api/auth/service/MealTagService.java
+++ b/src/main/java/com/moyorak/api/auth/service/MealTagService.java
@@ -100,6 +100,18 @@ public class MealTagService {
         toSoftDelete.forEach(MealTag::delete);
     }
 
+    /**
+     * 회원의 알러지 + 비선호 음식 정보 초기화 <br>
+     * <br>
+     * 회원 탈퇴 시, 회원의 식사 태그 정보 미사용 처리합니다.
+     *
+     * @param userId 회원 고유 ID
+     */
+    @Transactional
+    public void clear(final Long userId) {
+        mealTagRepository.clearByUserId(userId);
+    }
+
     private void validateWithinLimit(long finalCount, MealTagType type) {
         if (finalCount > MAX_ITEMS_PER_TYPE) {
             throw new BusinessException(

--- a/src/main/java/com/moyorak/api/auth/service/UserFacade.java
+++ b/src/main/java/com/moyorak/api/auth/service/UserFacade.java
@@ -1,0 +1,52 @@
+package com.moyorak.api.auth.service;
+
+import com.moyorak.api.team.service.TeamUserService;
+import com.moyorak.config.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserService userService;
+
+    private final AuthService authService;
+
+    private final MealTagService mealTagService;
+
+    private final TeamUserService teamUserService;
+
+    /**
+     * 회원 탈퇴를 처리합니다. <br>
+     * <br>
+     * 회원 탈퇴 시 다음과 같은 작업을 수행합니다:<br>
+     * 1. 팀에 관리자로 속해 있는지 검증<br>
+     * 2. 회원 정보 제거<br>
+     * 3. 과거 팀 소속 정보 제거<br>
+     * 4. 비선호 + 알러지 정보 초기화<br>
+     * 5. 토큰 초기화
+     *
+     * @param userId 회원 고유 ID
+     */
+    @Transactional
+    public void unregister(final Long userId) {
+        // 1. 팀에 관리자로 속해 있는지 검증
+        if (teamUserService.isTeamAdmin(userId)) {
+            throw new BusinessException("팀 관리자는 탈퇴할 수 없습니다.");
+        }
+
+        // 2. 회원 정보 제거
+        userService.unregister(userId);
+
+        // 3. 과거 팀 소속 정보 제거
+        teamUserService.clear(userId);
+
+        // 4. 비선호 + 알러지 정보 초기화
+        mealTagService.clear(userId);
+
+        // 5. 토큰 초기화
+        authService.signOut(userId);
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/service/UserService.java
+++ b/src/main/java/com/moyorak/api/auth/service/UserService.java
@@ -1,6 +1,7 @@
 package com.moyorak.api.auth.service;
 
 import com.moyorak.api.auth.domain.User;
+import com.moyorak.api.auth.domain.UserNotFoundException;
 import com.moyorak.api.auth.dto.SignUpRequest;
 import com.moyorak.api.auth.dto.SignUpResponse;
 import com.moyorak.api.auth.repository.UserRepository;
@@ -28,5 +29,21 @@ public class UserService {
         final User user = request.toEntity();
 
         return SignUpResponse.create(userRepository.save(user).getId());
+    }
+
+    /**
+     * 회원 탈퇴 <br>
+     * <br>
+     * 회원 탈퇴 시, 회원의 이름, 생년월일, 성별, 알러지 + 비선호 음식, 회사, 팀 정보가 제거됩니다.
+     *
+     * @param id 회원 ID
+     */
+    @Transactional
+    public void unregister(final Long id) {
+        // 1. 회원 정보가 있는지 조회
+        User user = userRepository.findByIdAndUse(id, true).orElseThrow(UserNotFoundException::new);
+
+        // 2. 사용하지 않는 정보 clear
+        user.unregister();
     }
 }

--- a/src/main/java/com/moyorak/api/team/domain/TeamUser.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamUser.java
@@ -48,7 +48,7 @@ public class TeamUser extends AuditInformation {
     private boolean use = true;
 
     @Comment("유저 고유 ID")
-    @Column(name = "member_id", nullable = false, columnDefinition = "bigint")
+    @Column(name = "member_id", columnDefinition = "bigint")
     private Long userId;
 
     @Comment("팀 고유 ID")

--- a/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
@@ -4,6 +4,7 @@ import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserStatus;
 import com.moyorak.api.team.dto.TeamUserResponse;
 import jakarta.persistence.QueryHint;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,12 +13,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
-
 public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     @Query(
-        """
+            """
                     SELECT tu
                     FROM TeamUser tu
                     JOIN FETCH tu.team t
@@ -27,24 +26,24 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
                     and tu.use = :use
             """)
     Optional<TeamUser> findWithTeamAndCompany(
-        @Param("teamId") Long teamId, @Param("userId") Long userId, @Param("use") boolean use);
+            @Param("teamId") Long teamId, @Param("userId") Long userId, @Param("use") boolean use);
 
     @Query(
-        """
+            """
                     SELECT tu
                     FROM TeamUser tu
                     JOIN Team t ON tu.team.id = t.id
                     WHERE tu.userId = :userId AND tu.team.id = :teamId AND tu.use = :use
             """)
     @QueryHints(
-        @QueryHint(
-            name = "org.hibernate.comment",
-            value = "TeamUserRepository.findByUserIdAndTeamIdAndUse : 팀 멤버를 조회합니다."))
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamUserRepository.findByUserIdAndTeamIdAndUse : 팀 멤버를 조회합니다."))
     Optional<TeamUser> findByUserIdAndTeamIdAndUse(
-        @Param("userId") Long userId, @Param("teamId") Long teamId, @Param("use") boolean use);
+            @Param("userId") Long userId, @Param("teamId") Long teamId, @Param("use") boolean use);
 
     @Query(
-        """
+            """
             SELECT new com.moyorak.api.team.dto.TeamUserResponse(tu.id, u.name, u.email, u.profileImage, tu.status)
             FROM TeamUser tu
             JOIN User u ON tu.userId = u.id
@@ -52,17 +51,17 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
             AND tu.use = :use AND u.use = true
             """)
     @QueryHints(
-        @QueryHint(
-            name = "org.hibernate.comment",
-            value = "TeamUserRepository.findByConditions : 팀 멤버 리스트를 조회합니다."))
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamUserRepository.findByConditions : 팀 멤버 리스트를 조회합니다."))
     Page<TeamUserResponse> findByConditions(
-        @Param("teamId") Long teamId,
-        @Param("status") TeamUserStatus status,
-        @Param("use") boolean use,
-        Pageable pageable);
+            @Param("teamId") Long teamId,
+            @Param("status") TeamUserStatus status,
+            @Param("use") boolean use,
+            Pageable pageable);
 
     @Query(
-        """
+            """
         SELECT exists(
             SELECT 1
             FROM TeamUser tu
@@ -73,29 +72,29 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
         )
     """)
     @QueryHints(
-        @QueryHint(
-            name = "org.hibernate.comment",
-            value = "TeamUserRepository.isTeamAdmin : 팀에 관리자로 존재하는 데이터가 있는지 조회합니다."))
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamUserRepository.isTeamAdmin : 팀에 관리자로 존재하는 데이터가 있는지 조회합니다."))
     boolean isTeamAdmin(@Param("userId") Long userId);
 
     @QueryHints(
-        @QueryHint(
-            name = "org.hibernate.comment",
-            value = "TeamUserRepository.findByIdAndUseAndStatus : 팀 멤버를 조회합니다."))
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamUserRepository.findByIdAndUseAndStatus : 팀 멤버를 조회합니다."))
     Optional<TeamUser> findByIdAndUseAndStatus(Long id, boolean use, TeamUserStatus status);
 
     boolean existsByUserIdAndUseIsTrue(Long userId);
 
     @Modifying
     @Query(
-        """
+            """
                   UPDATE TeamUser tu
                   SET tu.userId = null
                   WHERE tu.userId = :userId
             """)
     @QueryHints(
-        @QueryHint(
-            name = "org.hibernate.comment",
-            value = "TeamUserRepository.clearUserId : 과거 팀에 속해있던 정보를 clear합니다."))
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamUserRepository.clearUserId : 과거 팀에 속해있던 정보를 clear합니다."))
     int clearUserId(final Long userId);
 }

--- a/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
@@ -4,66 +4,98 @@ import com.moyorak.api.team.domain.TeamUser;
 import com.moyorak.api.team.domain.TeamUserStatus;
 import com.moyorak.api.team.dto.TeamUserResponse;
 import jakarta.persistence.QueryHint;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     @Query(
-            """
-        SELECT tu
-        FROM TeamUser tu
-        JOIN FETCH tu.team t
-        JOIN FETCH t.company
-        WHERE tu.userId = :userId
-        AND tu.team.id = :teamId
-        and tu.use = :use
-""")
+        """
+                    SELECT tu
+                    FROM TeamUser tu
+                    JOIN FETCH tu.team t
+                    JOIN FETCH t.company
+                    WHERE tu.userId = :userId
+                    AND tu.team.id = :teamId
+                    and tu.use = :use
+            """)
     Optional<TeamUser> findWithTeamAndCompany(
-            @Param("teamId") Long teamId, @Param("userId") Long userId, @Param("use") boolean use);
+        @Param("teamId") Long teamId, @Param("userId") Long userId, @Param("use") boolean use);
 
     @Query(
-            """
-        SELECT tu
-        FROM TeamUser tu
-        JOIN Team t ON tu.team.id = t.id
-        WHERE tu.userId = :userId AND tu.team.id = :teamId AND tu.use = :use
-""")
+        """
+                    SELECT tu
+                    FROM TeamUser tu
+                    JOIN Team t ON tu.team.id = t.id
+                    WHERE tu.userId = :userId AND tu.team.id = :teamId AND tu.use = :use
+            """)
     @QueryHints(
-            @QueryHint(
-                    name = "org.hibernate.comment",
-                    value = "TeamUserRepository.findByUserIdAndTeamIdAndUse : 팀 멤버를 조회합니다."))
+        @QueryHint(
+            name = "org.hibernate.comment",
+            value = "TeamUserRepository.findByUserIdAndTeamIdAndUse : 팀 멤버를 조회합니다."))
     Optional<TeamUser> findByUserIdAndTeamIdAndUse(
-            @Param("userId") Long userId, @Param("teamId") Long teamId, @Param("use") boolean use);
+        @Param("userId") Long userId, @Param("teamId") Long teamId, @Param("use") boolean use);
 
     @Query(
-            """
-        SELECT new com.moyorak.api.team.dto.TeamUserResponse(tu.id, u.name, u.email, u.profileImage, tu.status)
-        FROM TeamUser tu
-        JOIN User u ON tu.userId = u.id
-        WHERE tu.team.id = :teamId AND tu.status = :status
-        AND tu.use = :use AND u.use = true
-        """)
+        """
+            SELECT new com.moyorak.api.team.dto.TeamUserResponse(tu.id, u.name, u.email, u.profileImage, tu.status)
+            FROM TeamUser tu
+            JOIN User u ON tu.userId = u.id
+            WHERE tu.team.id = :teamId AND tu.status = :status
+            AND tu.use = :use AND u.use = true
+            """)
     @QueryHints(
-            @QueryHint(
-                    name = "org.hibernate.comment",
-                    value = "TeamUserRepository.findByConditions : 팀 멤버 리스트를 조회합니다."))
+        @QueryHint(
+            name = "org.hibernate.comment",
+            value = "TeamUserRepository.findByConditions : 팀 멤버 리스트를 조회합니다."))
     Page<TeamUserResponse> findByConditions(
-            @Param("teamId") Long teamId,
-            @Param("status") TeamUserStatus status,
-            @Param("use") boolean use,
-            Pageable pageable);
+        @Param("teamId") Long teamId,
+        @Param("status") TeamUserStatus status,
+        @Param("use") boolean use,
+        Pageable pageable);
+
+    @Query(
+        """
+        SELECT exists(
+            SELECT 1
+            FROM TeamUser tu
+            JOIN Team t ON tu.team.id = t.id
+            WHERE tu.userId = :userId
+            AND tu.role = '관리자'
+            AND tu.use = true
+        )
+    """)
+    @QueryHints(
+        @QueryHint(
+            name = "org.hibernate.comment",
+            value = "TeamUserRepository.isTeamAdmin : 팀에 관리자로 존재하는 데이터가 있는지 조회합니다."))
+    boolean isTeamAdmin(@Param("userId") Long userId);
 
     @QueryHints(
-            @QueryHint(
-                    name = "org.hibernate.comment",
-                    value = "TeamUserRepository.findByIdAndUseAndStatus : 팀 멤버를 조회합니다."))
+        @QueryHint(
+            name = "org.hibernate.comment",
+            value = "TeamUserRepository.findByIdAndUseAndStatus : 팀 멤버를 조회합니다."))
     Optional<TeamUser> findByIdAndUseAndStatus(Long id, boolean use, TeamUserStatus status);
 
     boolean existsByUserIdAndUseIsTrue(Long userId);
+
+    @Modifying
+    @Query(
+        """
+                  UPDATE TeamUser tu
+                  SET tu.userId = null
+                  WHERE tu.userId = :userId
+            """)
+    @QueryHints(
+        @QueryHint(
+            name = "org.hibernate.comment",
+            value = "TeamUserRepository.clearUserId : 과거 팀에 속해있던 정보를 clear합니다."))
+    int clearUserId(final Long userId);
 }

--- a/src/main/java/com/moyorak/api/team/service/TeamUserService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamUserService.java
@@ -98,7 +98,7 @@ public class TeamUserService {
             throw new BusinessException("해당 팀의 팀원이 아닙니다.");
         }
 
-        teamUser.changeStatus(TeamUserStatus.APPROVED);
+        teamUser.approve();
     }
 
     /**

--- a/src/test/java/com/moyorak/api/auth/domain/GenderTest.java
+++ b/src/test/java/com/moyorak/api/auth/domain/GenderTest.java
@@ -45,6 +45,21 @@ class GenderTest {
             assertThat(result).isEqualTo(expectedResult);
         }
 
+        @Test
+        @DisplayName("탈퇴를 의미하는 UNREGISTER를 입력하면, Gender의 UNREGISTER로 반한합니다.")
+        void unregisterSuccess() {
+            // given
+            final String input = "UNREGISTER";
+
+            final Gender expectedResult = Gender.UNREGISTER;
+
+            // when
+            final Gender result = Gender.from(input);
+
+            // then
+            assertThat(result).isEqualTo(expectedResult);
+        }
+
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = " ")

--- a/src/test/java/com/moyorak/api/auth/domain/UserTokenTest.java
+++ b/src/test/java/com/moyorak/api/auth/domain/UserTokenTest.java
@@ -49,14 +49,19 @@ class UserTokenTest {
     @DisplayName("토큰을 초기화합니다.")
     void clear() {
         // given
-        final String token = "EXAMPLE-TOKEN";
-        final UserToken userToken = UserTokenFixture.fixture(1L, token);
+        final String accessToken = "EXAMPLE-TOKEN";
+        final String refreshToken = "EXAMPLE-REFRESH-TOKEN";
+        final UserToken userToken = UserTokenFixture.fixture(1L, accessToken, refreshToken);
 
         // when
         userToken.clear();
 
         // then
-        assertThat(userToken.getAccessToken()).isNull();
+        assertSoftly(
+                it -> {
+                    it.assertThat(userToken.getAccessToken()).isNull();
+                    it.assertThat(userToken.getRefreshToken()).isNull();
+                });
     }
 
     @Nested


### PR DESCRIPTION
## 📌 주요 변경 사항
- 회원 탈퇴 기능을 추가하였습니다.
회원 탈퇴 기능은 아래와 같은 검증을 통해 처리 되게 됩니다.
1. 팀에 관리자로 속해있는지를 검증합니다.
    - 관리자로 되어 있을 경우 탈퇴 reject이 됩니다.
2. 회원 정보를 제거합니다.
    - 회원 정보가 존재하지 않는 경우 reject이 됩니다.
3. 과거 팀 소속 정보 제거
4. 비선호 + 알러지 정보 초기화
5. 토큰 초기화
    - 로그인 정보가 유효하지 않으면 reject이 됩니다.

- 기능이 많아지면서, 코드를 빠르게 파악하기 어려워 javadoc 주석을 추가하였습니다.
- API 마다의 어떠한 응답을 내려줘야 하는지를 `@ApiResponse`를 통해 직접 명시하였습니다.

- 머지 되면, 테이블의 속성도 수정이 필요합니다. 
    - MEMBER
        - gender : varchar(6) -> varchar(10)
        - profile_image : nullable 
   - TEAMUSER
       - member_id : nullable
---

## 📝 코멘트
- 회원 탈퇴 기능 추가
