### PR TITLE
refactor: #216 회원 가입 전에 요청해야 하는 API의 경우 토큰 없이 요청하도록 수정

### DIFF
--- a/src/main/java/com/moyorak/api/company/controller/CompanyController.java
+++ b/src/main/java/com/moyorak/api/company/controller/CompanyController.java
@@ -5,7 +5,6 @@ import com.moyorak.api.company.dto.CompanySearchListResponse;
 import com.moyorak.api.company.dto.CompanySearchRequest;
 import com.moyorak.api.company.service.CompanyService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/companies")
 @RequiredArgsConstructor
-@SecurityRequirement(name = "JWT")
 @Tag(name = "[회사] 회사 API", description = "회사를 위한 API 입니다.")
 class CompanyController {
 

--- a/src/main/java/com/moyorak/api/team/controller/TeamController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamController.java
@@ -7,7 +7,6 @@ import com.moyorak.api.team.dto.TeamSearchRequest;
 import com.moyorak.api.team.service.TeamFacade;
 import com.moyorak.api.team.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-@SecurityRequirement(name = "JWT")
 @Tag(name = "[회사] [팀] 팀 관리 API", description = "팀 관리를 위한 API 입니다.")
 class TeamController {
 

--- a/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moyorak/config/security/JwtAuthenticationFilter.java
@@ -68,7 +68,9 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return uri.startsWith("/api/auth/sign-in")
                 || uri.startsWith("/api/auth/refresh")
-                || uri.startsWith("/api/user/sign-up");
+                || uri.startsWith("/api/user/sign-up")
+                || uri.startsWith("/api/companies/\\d+$")
+                || uri.startsWith("/api/companies/\\d+$/teams");
     }
 
     private void validToken(final Authentication authentication, final String token) {


### PR DESCRIPTION
## 📌 주요 변경 사항
- 회원 가입 전에 토큰이 없는데, 회사 검색이나 등록, 팀 검색이나 등록은 회원 가입전에 이루어져야 해서 토큰 필요 설정을 제거

---

## 📝 코멘트
- 회원 가입 전에 요청해야 하는 API의 경우 토큰 없이 요청하도록 수정