### PR TITLE
refactor: #217 이미지 서비스 재사용을 위해 컴포넌트로 분리

### DIFF
--- a/src/main/java/com/moyorak/api/image/ImageStore.java
+++ b/src/main/java/com/moyorak/api/image/ImageStore.java
@@ -1,0 +1,70 @@
+package com.moyorak.api.image;
+
+import com.moyorak.api.image.dto.ImageDeleteRequest;
+import com.moyorak.api.image.dto.ImagePresignedUrlListRequest;
+import com.moyorak.api.image.dto.ImagePresignedUrlListResponse;
+import com.moyorak.api.image.dto.ImagePresignedUrlRequest;
+import com.moyorak.api.image.dto.ImagePresignedUrlResponse;
+import com.moyorak.api.image.dto.ImageSaveRequest;
+import com.moyorak.api.image.dto.ImageSaveResponse;
+import com.moyorak.api.review.dto.PhotoPath;
+import com.moyorak.api.review.dto.ReviewPhotoPath;
+import com.moyorak.config.exception.BusinessException;
+import com.moyorak.infra.aws.s3.S3Adapter;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageStore {
+
+    private final S3Adapter s3Adapter;
+
+    public ImageSaveResponse generateUrl(final ImageSaveRequest request) {
+        final String uuid = UUID.randomUUID().toString();
+        final String path =
+                s3Adapter.createFilePath(LocalDateTime.now(), uuid, request.extensionName());
+        final String url = s3Adapter.createPreSignUrl(path, request.extensionName());
+
+        return ImageSaveResponse.from(url, path);
+    }
+
+    public void remove(final Long userId, final ImageDeleteRequest request) {
+        if (!userId.equals(request.userId())) {
+            throw new BusinessException("사용자 ID가 일치하지 않습니다.");
+        }
+
+        s3Adapter.delete(request.path());
+    }
+
+    public ImagePresignedUrlResponse getUrl(final ImagePresignedUrlRequest request) {
+        final String url = s3Adapter.getPresignedUrl(request.path());
+
+        return ImagePresignedUrlResponse.from(url);
+    }
+
+    public ImagePresignedUrlListResponse getUrls(final ImagePresignedUrlListRequest requests) {
+        return ImagePresignedUrlListResponse.from(
+                requests.paths().stream().map(this::getUrl).collect(Collectors.toList()));
+    }
+
+    // TODO 리뷰 도메인쪽으로 이동후에는 삭제
+    public List<ReviewPhotoPath> getUrlsFomReview(final List<ReviewPhotoPath> reviewPhotoPaths) {
+        return reviewPhotoPaths.stream()
+                .map(
+                        r ->
+                                new ReviewPhotoPath(
+                                        r.reviewId(),
+                                        s3Adapter.getPresignedUrl(r.reviewPhotoPath())))
+                .toList();
+    }
+
+    public Page<PhotoPath> getUrlsFomPhotoPaths(final Page<PhotoPath> photoPaths) {
+        return photoPaths.map(p -> new PhotoPath(s3Adapter.getPresignedUrl(p.path())));
+    }
+}

--- a/src/main/java/com/moyorak/api/image/service/ImageService.java
+++ b/src/main/java/com/moyorak/api/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.moyorak.api.image.service;
 
+import com.moyorak.api.image.ImageStore;
 import com.moyorak.api.image.dto.ImageDeleteRequest;
 import com.moyorak.api.image.dto.ImagePresignedUrlListRequest;
 import com.moyorak.api.image.dto.ImagePresignedUrlListResponse;
@@ -9,12 +10,7 @@ import com.moyorak.api.image.dto.ImageSaveRequest;
 import com.moyorak.api.image.dto.ImageSaveResponse;
 import com.moyorak.api.review.dto.PhotoPath;
 import com.moyorak.api.review.dto.ReviewPhotoPath;
-import com.moyorak.config.exception.BusinessException;
-import com.moyorak.infra.aws.s3.S3Adapter;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -23,47 +19,30 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ImageService {
 
-    private final S3Adapter s3Adapter;
+    private final ImageStore imageStore;
 
     public ImageSaveResponse generateUrl(final ImageSaveRequest request) {
-        final String uuid = UUID.randomUUID().toString();
-        final String path =
-                s3Adapter.createFilePath(LocalDateTime.now(), uuid, request.extensionName());
-        final String url = s3Adapter.createPreSignUrl(path, request.extensionName());
-
-        return ImageSaveResponse.from(url, path);
+        return imageStore.generateUrl(request);
     }
 
     public void remove(final Long userId, final ImageDeleteRequest request) {
-        if (!userId.equals(request.userId())) {
-            throw new BusinessException("사용자 ID가 일치하지 않습니다.");
-        }
-
-        s3Adapter.delete(request.path());
+        imageStore.remove(userId, request);
     }
 
     public ImagePresignedUrlResponse getUrl(final ImagePresignedUrlRequest request) {
-        final String url = s3Adapter.getPresignedUrl(request.path());
-
-        return ImagePresignedUrlResponse.from(url);
+        return imageStore.getUrl(request);
     }
 
     public ImagePresignedUrlListResponse getUrls(final ImagePresignedUrlListRequest requests) {
-        return ImagePresignedUrlListResponse.from(
-                requests.paths().stream().map(this::getUrl).collect(Collectors.toList()));
+        return imageStore.getUrls(requests);
     }
 
+    // TODO 리뷰 도메인쪽으로 이동해야함
     public List<ReviewPhotoPath> getUrlsFomReview(final List<ReviewPhotoPath> reviewPhotoPaths) {
-        return reviewPhotoPaths.stream()
-                .map(
-                        r ->
-                                new ReviewPhotoPath(
-                                        r.reviewId(),
-                                        s3Adapter.getPresignedUrl(r.reviewPhotoPath())))
-                .toList();
+        return imageStore.getUrlsFomReview(reviewPhotoPaths);
     }
 
     public Page<PhotoPath> getUrlsFomPhotoPaths(final Page<PhotoPath> photoPaths) {
-        return photoPaths.map(p -> new PhotoPath(s3Adapter.getPresignedUrl(p.path())));
+        return imageStore.getUrlsFomPhotoPaths(photoPaths);
     }
 }

--- a/src/test/java/com/moyorak/api/image/service/ImageStoreTest.java
+++ b/src/test/java/com/moyorak/api/image/service/ImageStoreTest.java
@@ -3,6 +3,7 @@ package com.moyorak.api.image.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.moyorak.api.image.ImageStore;
 import com.moyorak.api.image.dto.ImageDeleteRequest;
 import com.moyorak.api.image.dto.ImageDeleteRequestFixture;
 import com.moyorak.config.exception.BusinessException;
@@ -16,9 +17,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class ImageServiceTest {
+class ImageStoreTest {
 
-    @InjectMocks private ImageService imageService;
+    @InjectMocks private ImageStore imageStore;
 
     @Mock private S3Adapter s3Adapter;
 
@@ -34,7 +35,7 @@ class ImageServiceTest {
             final ImageDeleteRequest request = ImageDeleteRequestFixture.fixture(3L);
 
             // when & then
-            assertThatThrownBy(() -> imageService.remove(userId, request))
+            assertThatThrownBy(() -> imageStore.remove(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("사용자 ID가 일치하지 않습니다.");
         }
@@ -47,7 +48,7 @@ class ImageServiceTest {
             final ImageDeleteRequest request = ImageDeleteRequestFixture.fixture(userId);
 
             // when & then
-            assertDoesNotThrow(() -> imageService.remove(userId, request));
+            assertDoesNotThrow(() -> imageStore.remove(userId, request));
         }
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 이미지 서비스 재사용을 위해 컴포넌트로 분리

---

## 📝 코멘트
- presignurl로 변경하는 기능을 다른 도메인에서 사용하기 위해 이미지 서비스를 컴포넌트로 분리합니다.
