### PR TITLE
feat: #228 팀 멤버 강퇴

### DIFF
--- a/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
+++ b/src/main/java/com/moyorak/api/team/controller/TeamUserController.java
@@ -81,4 +81,13 @@ class TeamUserController {
         teamUserManagementService.updateRole(
                 userPrincipal.getId(), teamId, teamMemberId, request.role());
     }
+
+    @DeleteMapping("/teams/{teamId}/team-members/{teamMemberId}")
+    @Operation(summary = "팀 멤버 강퇴", description = "팀 멤버를 강퇴합니다.")
+    public void expel(
+            @PathVariable @Positive final Long teamId,
+            @PathVariable @Positive final Long teamMemberId,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        teamUserManagementService.expel(userPrincipal.getId(), teamId, teamMemberId);
+    }
 }

--- a/src/main/java/com/moyorak/api/team/domain/TeamUser.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamUser.java
@@ -108,6 +108,11 @@ public class TeamUser extends AuditInformation {
         use = false;
     }
 
+    public void expel() {
+        status = TeamUserStatus.WITHDRAWN;
+        use = false;
+    }
+
     public void changeRole(TeamRole role) {
         this.role = role;
     }

--- a/src/test/java/com/moyorak/api/team/domain/TeamUserTest.java
+++ b/src/test/java/com/moyorak/api/team/domain/TeamUserTest.java
@@ -93,4 +93,24 @@ class TeamUserTest {
             assertThat(user.getStatus()).isEqualTo(TeamUserStatus.WITHDRAWN);
         }
     }
+
+    @Nested
+    @DisplayName("expel 메서드는")
+    class Expel {
+
+        @Test
+        @DisplayName("status를 WITHDRAWN으로, use를 false로 변경한다.")
+        void updateStatusAndUse() {
+            // given
+            final TeamUser user =
+                    TeamUserFixture.fixture(TeamUserStatus.APPROVED, TeamRole.TEAM_ADMIN, true);
+
+            // when
+            user.expel();
+
+            // then
+            assertThat(user.isUse()).isFalse();
+            assertThat(user.getStatus()).isEqualTo(TeamUserStatus.WITHDRAWN);
+        }
+    }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팀 멤버 강퇴 기능 개발

---

## 📝 코멘트
팀 관리자만 강퇴할 수 있도록 구현했습니다.
본인 강퇴를 막고 같은 팀원인 경우에만 강퇴를 허용하도록 했습니다.