### PR TITLE
feat:#238 파티 목록 조회

### DIFF
--- a/src/main/java/com/moyorak/api/party/controller/PartyController.java
+++ b/src/main/java/com/moyorak/api/party/controller/PartyController.java
@@ -1,0 +1,39 @@
+package com.moyorak.api.party.controller;
+
+import com.moyorak.api.auth.domain.UserPrincipal;
+import com.moyorak.api.party.dto.PartyListRequest;
+import com.moyorak.api.party.dto.PartyListResponse;
+import com.moyorak.api.party.service.PartyFacade;
+import com.moyorak.global.domain.ListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "[파티] 파티 API", description = "파티를 위한 API 입니다.")
+public class PartyController {
+    private final PartyFacade partyFacade;
+
+    @GetMapping("/teams/{teamId}/parties")
+    @Operation(summary = "파티 목록 조회", description = "파티 목록을 조회 합니다.")
+    public ListResponse<PartyListResponse> getParties(
+            @PathVariable @Positive final Long teamId,
+            @RequestBody @Valid PartyListRequest partyListRequest,
+            @AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        return partyFacade.getParties(teamId, userPrincipal.getId(), partyListRequest);
+    }
+}

--- a/src/main/java/com/moyorak/api/party/domain/Party.java
+++ b/src/main/java/com/moyorak/api/party/domain/Party.java
@@ -24,6 +24,10 @@ public class Party extends AuditInformation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Comment("팀 고유 ID")
+    @Column(name = "team_id", nullable = false, columnDefinition = "bigint")
+    private Long teamId;
+
     @Comment("파티 이름")
     @Column(name = "title", nullable = false, columnDefinition = "varchar(512)")
     private String title;

--- a/src/main/java/com/moyorak/api/party/domain/SelectionVoteInfo.java
+++ b/src/main/java/com/moyorak/api/party/domain/SelectionVoteInfo.java
@@ -26,6 +26,10 @@ public class SelectionVoteInfo extends AuditInformation {
     @Column(name = "id", nullable = false, columnDefinition = "bigint")
     private Long id;
 
+    @Comment("투표 시작 시간")
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
     @Comment("투표 마감 시간")
     @Column(name = "expired_date", nullable = false)
     private LocalDateTime expiredDate;

--- a/src/main/java/com/moyorak/api/party/dto/PartyAttendeeWithUserProfile.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyAttendeeWithUserProfile.java
@@ -1,0 +1,3 @@
+package com.moyorak.api.party.dto;
+
+public record PartyAttendeeWithUserProfile(Long partyId, Long userId, String userProfile) {}

--- a/src/main/java/com/moyorak/api/party/dto/PartyGeneralInfoProjection.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyGeneralInfoProjection.java
@@ -1,0 +1,13 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.api.party.domain.VoteStatus;
+import com.moyorak.api.party.domain.VoteType;
+import java.time.LocalDateTime;
+
+public record PartyGeneralInfoProjection(
+        Long id,
+        LocalDateTime startDate,
+        String title,
+        VoteType voteType,
+        VoteStatus voteStatus,
+        Long attendeeCount) {}

--- a/src/main/java/com/moyorak/api/party/dto/PartyListRequest.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyListRequest.java
@@ -1,0 +1,22 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.global.domain.ListRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@ParameterObject
+@Schema(title = "파티 목록 조회 요청 DTO")
+public class PartyListRequest extends ListRequest {
+    public PartyListRequest(Integer currentPage, Integer size) {
+        super(size, currentPage);
+    }
+
+    @Override
+    public Pageable toPageable() {
+        return PageRequest.of(super.getCurrentPage() - 1, super.getSize());
+    }
+}

--- a/src/main/java/com/moyorak/api/party/dto/PartyListRequest.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyListRequest.java
@@ -4,8 +4,6 @@ import com.moyorak.global.domain.ListRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 @Getter
 @ParameterObject
@@ -13,10 +11,5 @@ import org.springframework.data.domain.Pageable;
 public class PartyListRequest extends ListRequest {
     public PartyListRequest(Integer currentPage, Integer size) {
         super(size, currentPage);
-    }
-
-    @Override
-    public Pageable toPageable() {
-        return PageRequest.of(super.getCurrentPage() - 1, super.getSize());
     }
 }

--- a/src/main/java/com/moyorak/api/party/dto/PartyListResponse.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyListResponse.java
@@ -20,6 +20,7 @@ public record PartyListResponse(
         @Schema(description = "파티 참가자 수", example = "1") Long attendeeCount,
         @Schema(description = "파티 투표 후보 식당")
                 List<PartyRestaurantResponse> partyRestaurantResponseList,
+        @Schema(description = "유저 프로필 사진 리스트") List<String> userProfileList,
         @Schema(description = "유저 파티 참가 여부", example = "true") Boolean isParticipating) {
     public static List<PartyListResponse> from(
             List<PartyGeneralInfoProjection> partyGeneralInfoProjection,
@@ -36,6 +37,7 @@ public record PartyListResponse(
                                         p.attendeeCount(),
                                         PartyRestaurantResponse.fromList(
                                                 partyListStore.getRestaurantProjection(p.id())),
+                                        partyListStore.getUserProfile(p.id()),
                                         partyListStore.getParticipation(p.id()))))
                 .toList();
     }

--- a/src/main/java/com/moyorak/api/party/dto/PartyListResponse.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyListResponse.java
@@ -1,0 +1,47 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.api.party.domain.VoteStatus;
+import com.moyorak.api.party.domain.VoteType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@Schema(title = "[파티] 파티 목록 조회 응답 DTO")
+public record PartyListResponse(
+        @Schema(description = "파티 고유 ID", example = "1") Long id,
+        @Schema(description = "파티 투표 시작 시간", example = "2025-08-08 12:05:00")
+                LocalDateTime startDate,
+        @Schema(description = "파티 제목", example = "점심팟 모읍니다.") String title,
+        @Schema(description = "파티 투표 타입", example = "SELECT") VoteType voteType,
+        @Schema(description = "파티 투표 진행 상태", example = "VOTING") VoteStatus voteStatus,
+        @Schema(description = "파티 참가자 수", example = "1") Long attendeeCount,
+        @Schema(description = "파티 투표 후보 식당")
+                List<PartyRestaurantResponse> partyRestaurantResponseList,
+        @Schema(description = "유저 파티 참가 여부", example = "true") Boolean isParticipating) {
+    public static List<PartyListResponse> from(
+            List<PartyGeneralInfoProjection> partyGeneralInfoProjection,
+            PartyListStore partyListStore) {
+        return partyGeneralInfoProjection.stream()
+                .map(
+                        p ->
+                                (new PartyListResponse(
+                                        p.id(),
+                                        p.startDate(),
+                                        p.title(),
+                                        p.voteType(),
+                                        p.voteStatus(),
+                                        p.attendeeCount(),
+                                        PartyRestaurantResponse.fromList(
+                                                partyListStore.getRestaurantProjection(p.id())),
+                                        partyListStore.getParticipation(p.id()))))
+                .toList();
+    }
+
+    public static Page<PartyListResponse> toPage(
+            List<PartyListResponse> partyListResponseList, Pageable pageable) {
+        return new PageImpl<>(partyListResponseList, pageable, partyListResponseList.size());
+    }
+}

--- a/src/main/java/com/moyorak/api/party/dto/PartyListStore.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyListStore.java
@@ -1,0 +1,58 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.api.party.domain.PartyAttendee;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PartyListStore {
+    private final Map<Long, List<PartyRestaurantProjection>> restaurantMap;
+    private final Map<Long, Boolean> participationMap;
+
+    private PartyListStore(
+            final Map<Long, List<PartyRestaurantProjection>> restaurantMap,
+            final Map<Long, Boolean> participationMap) {
+        this.restaurantMap = restaurantMap;
+        this.participationMap = participationMap;
+    }
+
+    public static PartyListStore create(
+            final List<PartyRestaurantProjection> partyRestaurantProjections,
+            final List<PartyAttendee> partyAttendees,
+            final Long userId) {
+        // 파티별 식당 후보 리스트 맵
+        final Map<Long, List<PartyRestaurantProjection>> restaurantMap =
+                partyRestaurantProjections.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        PartyRestaurantProjection
+                                                ::id, // PartyRestaurantProjection에서 파티 ID
+                                        Collectors.toList()));
+
+        // 파티별 해당 userId의 참석 여부 맵
+        final Map<Long, Boolean> participationMap =
+                partyAttendees.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        PartyAttendee::getPartyId,
+                                        Collectors.collectingAndThen(
+                                                Collectors.toList(),
+                                                list ->
+                                                        list.stream()
+                                                                .anyMatch(
+                                                                        pa ->
+                                                                                pa.getUserId()
+                                                                                        .equals(
+                                                                                                userId)))));
+
+        return new PartyListStore(restaurantMap, participationMap);
+    }
+
+    public List<PartyRestaurantProjection> getRestaurantProjection(final Long partyId) {
+        return restaurantMap.getOrDefault(partyId, List.of());
+    }
+
+    public Boolean getParticipation(final Long partyId) {
+        return participationMap.getOrDefault(partyId, false);
+    }
+}

--- a/src/main/java/com/moyorak/api/party/dto/PartyListStore.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyListStore.java
@@ -1,6 +1,5 @@
 package com.moyorak.api.party.dto;
 
-import com.moyorak.api.party.domain.PartyAttendee;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -8,44 +7,54 @@ import java.util.stream.Collectors;
 public class PartyListStore {
     private final Map<Long, List<PartyRestaurantProjection>> restaurantMap;
     private final Map<Long, Boolean> participationMap;
+    private final Map<Long, List<String>> userProfileMap;
 
     private PartyListStore(
             final Map<Long, List<PartyRestaurantProjection>> restaurantMap,
-            final Map<Long, Boolean> participationMap) {
+            final Map<Long, Boolean> participationMap,
+            final Map<Long, List<String>> userProfileMap) {
         this.restaurantMap = restaurantMap;
         this.participationMap = participationMap;
+        this.userProfileMap = userProfileMap;
     }
 
     public static PartyListStore create(
             final List<PartyRestaurantProjection> partyRestaurantProjections,
-            final List<PartyAttendee> partyAttendees,
+            final List<PartyAttendeeWithUserProfile> partyAttendees,
             final Long userId) {
         // 파티별 식당 후보 리스트 맵
         final Map<Long, List<PartyRestaurantProjection>> restaurantMap =
                 partyRestaurantProjections.stream()
                         .collect(
                                 Collectors.groupingBy(
-                                        PartyRestaurantProjection
-                                                ::id, // PartyRestaurantProjection에서 파티 ID
-                                        Collectors.toList()));
+                                        PartyRestaurantProjection::id, Collectors.toList()));
 
         // 파티별 해당 userId의 참석 여부 맵
         final Map<Long, Boolean> participationMap =
                 partyAttendees.stream()
                         .collect(
                                 Collectors.groupingBy(
-                                        PartyAttendee::getPartyId,
+                                        PartyAttendeeWithUserProfile::partyId,
                                         Collectors.collectingAndThen(
                                                 Collectors.toList(),
                                                 list ->
                                                         list.stream()
                                                                 .anyMatch(
                                                                         pa ->
-                                                                                pa.getUserId()
+                                                                                pa.userId()
                                                                                         .equals(
                                                                                                 userId)))));
+        // 파티별 유저 프로필 리스트 맵
+        final Map<Long, List<String>> userProfileMap =
+                partyAttendees.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        PartyAttendeeWithUserProfile::partyId,
+                                        Collectors.mapping(
+                                                PartyAttendeeWithUserProfile::userProfile,
+                                                Collectors.toList())));
 
-        return new PartyListStore(restaurantMap, participationMap);
+        return new PartyListStore(restaurantMap, participationMap, userProfileMap);
     }
 
     public List<PartyRestaurantProjection> getRestaurantProjection(final Long partyId) {
@@ -54,5 +63,9 @@ public class PartyListStore {
 
     public Boolean getParticipation(final Long partyId) {
         return participationMap.getOrDefault(partyId, false);
+    }
+
+    public List<String> getUserProfile(final Long partyId) {
+        return userProfileMap.getOrDefault(partyId, List.of());
     }
 }

--- a/src/main/java/com/moyorak/api/party/dto/PartyRestaurantProjection.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyRestaurantProjection.java
@@ -1,0 +1,10 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+
+public record PartyRestaurantProjection(
+        Long id,
+        String name,
+        RestaurantCategory restaurantCategory,
+        double averageReviewScore,
+        Integer reviewCount) {}

--- a/src/main/java/com/moyorak/api/party/dto/PartyRestaurantResponse.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyRestaurantResponse.java
@@ -1,0 +1,31 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Schema(title = "[파티] 파티 투표 후보 식당 응답 DTO")
+public record PartyRestaurantResponse(
+        @Schema(description = "파티 후보 식당 이름", example = "음식점") String name,
+        @Schema(description = "파티 후보 식당 카테고리", example = "WESTERN")
+                RestaurantCategory restaurantCategory,
+        @Schema(description = "파티 후보 식당 리뷰 점수", example = "1.0") double reviewScore,
+        @Schema(description = "파티 후보 식당 리뷰 갯수", example = "1") Integer reviewCount) {
+
+    public static PartyRestaurantResponse from(
+            PartyRestaurantProjection partyRestaurantProjection) {
+        return new PartyRestaurantResponse(
+                partyRestaurantProjection.name(),
+                partyRestaurantProjection.restaurantCategory(),
+                partyRestaurantProjection.averageReviewScore(),
+                partyRestaurantProjection.reviewCount());
+    }
+
+    public static List<PartyRestaurantResponse> fromList(
+            List<PartyRestaurantProjection> partyRestaurantProjectionList) {
+        return partyRestaurantProjectionList.stream()
+                .map(PartyRestaurantResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/moyorak/api/party/repository/PartyAttendeeRepository.java
+++ b/src/main/java/com/moyorak/api/party/repository/PartyAttendeeRepository.java
@@ -1,0 +1,9 @@
+package com.moyorak.api.party.repository;
+
+import com.moyorak.api.party.domain.PartyAttendee;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PartyAttendeeRepository extends CrudRepository<PartyAttendee, Long> {
+    List<PartyAttendee> findByPartyIdIn(List<Long> partyIds);
+}

--- a/src/main/java/com/moyorak/api/party/repository/PartyAttendeeRepository.java
+++ b/src/main/java/com/moyorak/api/party/repository/PartyAttendeeRepository.java
@@ -1,9 +1,30 @@
 package com.moyorak.api.party.repository;
 
 import com.moyorak.api.party.domain.PartyAttendee;
+import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
+import jakarta.persistence.QueryHint;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PartyAttendeeRepository extends CrudRepository<PartyAttendee, Long> {
-    List<PartyAttendee> findByPartyIdIn(List<Long> partyIds);
+    @Query(
+            """
+SELECT new com.moyorak.api.party.dto.PartyAttendeeWithUserProfile(
+      p.partyId,
+      p.userId,
+      u.profileImage
+)
+FROM PartyAttendee p
+JOIN User u ON p.userId = u.id AND u.use = true
+WHERE p.use = true
+  AND p.partyId IN (:partyIds)
+""")
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value =
+                            "PartyAttendeeRepository.findPartyAttendeeWithUser: 파티 ID들 로 파티 참가자 정보 조회"))
+    List<PartyAttendeeWithUserProfile> findPartyAttendeeWithUser(List<Long> partyIds);
 }

--- a/src/main/java/com/moyorak/api/party/repository/PartyRepository.java
+++ b/src/main/java/com/moyorak/api/party/repository/PartyRepository.java
@@ -1,0 +1,43 @@
+package com.moyorak.api.party.repository;
+
+import com.moyorak.api.party.domain.Party;
+import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
+import jakarta.persistence.QueryHint;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PartyRepository extends CrudRepository<Party, Long> {
+    List<Party> findAllByTeamIdAndUseIsTrue(Long teamId);
+
+    @Query(
+            """
+        SELECT new com.moyorak.api.party.dto.PartyGeneralInfoProjection(
+            p.id,
+            COALESCE(s.startDate, r.randomDate),
+            p.title,
+            v.type,
+            v.status,
+            COUNT(DISTINCT pa.id)
+        )
+        FROM Party p
+        LEFT JOIN Vote v
+               ON v.partyId = p.id AND v.use = true
+        LEFT JOIN SelectionVoteInfo s
+               ON s.voteId = v.id AND v.type = com.moyorak.api.party.domain.VoteType.SELECT AND s.use = true
+        LEFT JOIN RandomVoteInfo r
+               ON r.voteId = v.id AND v.type = com.moyorak.api.party.domain.VoteType.RANDOM AND r.use = true
+        LEFT JOIN PartyAttendee pa
+               ON pa.partyId = p.id AND pa.use = true
+        WHERE p.teamId = :teamId
+          AND p.use = true
+        GROUP BY
+          p.id, p.title, v.type, v.status, COALESCE(s.startDate, r.randomDate)
+        """)
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "PartyRepository.findPartyGeneralInfos: 팀 ID 로 파티 일반 정보 조회"))
+    List<PartyGeneralInfoProjection> findPartyGeneralInfos(Long teamId);
+}

--- a/src/main/java/com/moyorak/api/party/repository/PartyRestaurantRepository.java
+++ b/src/main/java/com/moyorak/api/party/repository/PartyRestaurantRepository.java
@@ -1,0 +1,35 @@
+package com.moyorak.api.party.repository;
+
+import com.moyorak.api.party.domain.VoteRestaurantCandidate;
+import com.moyorak.api.party.dto.PartyRestaurantProjection;
+import jakarta.persistence.QueryHint;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PartyRestaurantRepository extends CrudRepository<VoteRestaurantCandidate, Long> {
+
+    @Query(
+            """
+    SELECT new com.moyorak.api.party.dto.PartyRestaurantProjection(
+        v.partyId,
+            r.name,
+        r.category,
+        t.averageReviewScore,
+        t.reviewCount
+    )
+    FROM Vote v
+    JOIN VoteRestaurantCandidate vc ON vc.voteId = v.id AND vc.use = true
+    JOIN TeamRestaurant t           ON t.id = vc.teamRestaurantId AND t.use = true
+    JOIN t.restaurant r             WITH r.use = true
+    WHERE v.use = true
+      AND v.partyId IN (:partyIds)
+    """)
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value =
+                            "PartyRestaurantRepository.findPartyRestaurantInfo: 파티 ID들 로 파티 투표 후보 식당들 정보 조회"))
+    List<PartyRestaurantProjection> findPartyRestaurantInfo(List<Long> partyIds);
+}

--- a/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
@@ -5,12 +5,14 @@ import com.moyorak.api.party.repository.PartyAttendeeRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PartyAttendeeService {
     private final PartyAttendeeRepository partyAttendeeRepository;
 
+    @Transactional(readOnly = true)
     public List<PartyAttendee> findByPartyIds(List<Long> partyIds) {
         return partyAttendeeRepository.findByPartyIdIn(partyIds);
     }

--- a/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
@@ -1,6 +1,6 @@
 package com.moyorak.api.party.service;
 
-import com.moyorak.api.party.domain.PartyAttendee;
+import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
 import com.moyorak.api.party.repository.PartyAttendeeRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,8 @@ public class PartyAttendeeService {
     private final PartyAttendeeRepository partyAttendeeRepository;
 
     @Transactional(readOnly = true)
-    public List<PartyAttendee> findByPartyIds(List<Long> partyIds) {
-        return partyAttendeeRepository.findByPartyIdIn(partyIds);
+    public List<PartyAttendeeWithUserProfile> findPartyAttendeeWithUserByPartyIds(
+            List<Long> partyIds) {
+        return partyAttendeeRepository.findPartyAttendeeWithUser(partyIds);
     }
 }

--- a/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
@@ -1,0 +1,17 @@
+package com.moyorak.api.party.service;
+
+import com.moyorak.api.party.domain.PartyAttendee;
+import com.moyorak.api.party.repository.PartyAttendeeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PartyAttendeeService {
+    private final PartyAttendeeRepository partyAttendeeRepository;
+
+    public List<PartyAttendee> findByPartyIds(List<Long> partyIds) {
+        return partyAttendeeRepository.findByPartyIdIn(partyIds);
+    }
+}

--- a/src/main/java/com/moyorak/api/party/service/PartyFacade.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyFacade.java
@@ -1,0 +1,42 @@
+package com.moyorak.api.party.service;
+
+import com.moyorak.api.party.domain.PartyAttendee;
+import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
+import com.moyorak.api.party.dto.PartyListRequest;
+import com.moyorak.api.party.dto.PartyListResponse;
+import com.moyorak.api.party.dto.PartyListStore;
+import com.moyorak.api.party.dto.PartyRestaurantProjection;
+import com.moyorak.global.domain.ListResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PartyFacade {
+    private final PartyService partyService;
+    private final PartyAttendeeService partyAttendeeService;
+    private final PartyRestaurantService partyRestaurantService;
+
+    @Transactional(readOnly = true)
+    public ListResponse<PartyListResponse> getParties(
+            final Long teamId, final Long userId, final PartyListRequest partyListRequest) {
+        final List<PartyGeneralInfoProjection> parties = partyService.findPartyGeneralInfos(teamId);
+
+        final List<Long> partyIds = parties.stream().map(PartyGeneralInfoProjection::id).toList();
+
+        final List<PartyRestaurantProjection> partyRestaurantProjections =
+                partyRestaurantService.findPartyRestaurantInfo(partyIds);
+
+        final List<PartyAttendee> partyAttendees = partyAttendeeService.findByPartyIds(partyIds);
+
+        final PartyListStore partyListStore =
+                PartyListStore.create(partyRestaurantProjections, partyAttendees, userId);
+        final List<PartyListResponse> partyListResponses =
+                PartyListResponse.from(parties, partyListStore);
+
+        return ListResponse.from(
+                PartyListResponse.toPage(partyListResponses, partyListRequest.toPageable()));
+    }
+}

--- a/src/main/java/com/moyorak/api/party/service/PartyFacade.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyFacade.java
@@ -1,6 +1,6 @@
 package com.moyorak.api.party.service;
 
-import com.moyorak.api.party.domain.PartyAttendee;
+import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
 import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
 import com.moyorak.api.party.dto.PartyListRequest;
 import com.moyorak.api.party.dto.PartyListResponse;
@@ -29,7 +29,8 @@ public class PartyFacade {
         final List<PartyRestaurantProjection> partyRestaurantProjections =
                 partyRestaurantService.findPartyRestaurantInfo(partyIds);
 
-        final List<PartyAttendee> partyAttendees = partyAttendeeService.findByPartyIds(partyIds);
+        final List<PartyAttendeeWithUserProfile> partyAttendees =
+                partyAttendeeService.findPartyAttendeeWithUserByPartyIds(partyIds);
 
         final PartyListStore partyListStore =
                 PartyListStore.create(partyRestaurantProjections, partyAttendees, userId);

--- a/src/main/java/com/moyorak/api/party/service/PartyRestaurantService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyRestaurantService.java
@@ -1,0 +1,17 @@
+package com.moyorak.api.party.service;
+
+import com.moyorak.api.party.dto.PartyRestaurantProjection;
+import com.moyorak.api.party.repository.PartyRestaurantRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PartyRestaurantService {
+    private final PartyRestaurantRepository partyRestaurantRepository;
+
+    public List<PartyRestaurantProjection> findPartyRestaurantInfo(List<Long> partyIds) {
+        return partyRestaurantRepository.findPartyRestaurantInfo(partyIds);
+    }
+}

--- a/src/main/java/com/moyorak/api/party/service/PartyRestaurantService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyRestaurantService.java
@@ -5,12 +5,14 @@ import com.moyorak.api.party.repository.PartyRestaurantRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PartyRestaurantService {
     private final PartyRestaurantRepository partyRestaurantRepository;
 
+    @Transactional(readOnly = true)
     public List<PartyRestaurantProjection> findPartyRestaurantInfo(List<Long> partyIds) {
         return partyRestaurantRepository.findPartyRestaurantInfo(partyIds);
     }

--- a/src/main/java/com/moyorak/api/party/service/PartyService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyService.java
@@ -1,0 +1,24 @@
+package com.moyorak.api.party.service;
+
+import com.moyorak.api.party.domain.Party;
+import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
+import com.moyorak.api.party.repository.PartyRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PartyService {
+    private final PartyRepository partyRepository;
+
+    public List<Party> findByTeamId(final Long teamId) {
+        return partyRepository.findAllByTeamIdAndUseIsTrue(teamId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PartyGeneralInfoProjection> findPartyGeneralInfos(Long teamId) {
+        return partyRepository.findPartyGeneralInfos(teamId);
+    }
+}

--- a/src/main/java/com/moyorak/api/party/service/PartyService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyService.java
@@ -1,6 +1,5 @@
 package com.moyorak.api.party.service;
 
-import com.moyorak.api.party.domain.Party;
 import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
 import com.moyorak.api.party.repository.PartyRepository;
 import java.util.List;
@@ -12,10 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PartyService {
     private final PartyRepository partyRepository;
-
-    public List<Party> findByTeamId(final Long teamId) {
-        return partyRepository.findAllByTeamIdAndUseIsTrue(teamId);
-    }
 
     @Transactional(readOnly = true)
     public List<PartyGeneralInfoProjection> findPartyGeneralInfos(Long teamId) {

--- a/src/main/java/com/moyorak/api/party/service/PartyVoteService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyVoteService.java
@@ -1,0 +1,8 @@
+package com.moyorak.api.party.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PartyVoteService {}

--- a/src/test/java/com/moyorak/api/party/domain/PartyAttendeeFixture.java
+++ b/src/test/java/com/moyorak/api/party/domain/PartyAttendeeFixture.java
@@ -1,0 +1,14 @@
+package com.moyorak.api.party.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PartyAttendeeFixture {
+    public static PartyAttendee fixture(Long id, boolean use, Long partyId, Long userId) {
+        PartyAttendee partyAttendee = new PartyAttendee();
+        ReflectionTestUtils.setField(partyAttendee, "id", id);
+        ReflectionTestUtils.setField(partyAttendee, "use", use);
+        ReflectionTestUtils.setField(partyAttendee, "partyId", partyId);
+        ReflectionTestUtils.setField(partyAttendee, "userId", userId);
+        return partyAttendee;
+    }
+}

--- a/src/test/java/com/moyorak/api/party/domain/PartyAttendeeWithUserFixture.java
+++ b/src/test/java/com/moyorak/api/party/domain/PartyAttendeeWithUserFixture.java
@@ -1,0 +1,10 @@
+package com.moyorak.api.party.domain;
+
+import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
+
+public class PartyAttendeeWithUserFixture {
+    public static PartyAttendeeWithUserProfile fixture(
+            Long partyId, Long userId, String userProfile) {
+        return new PartyAttendeeWithUserProfile(partyId, userId, userProfile);
+    }
+}

--- a/src/test/java/com/moyorak/api/party/domain/PartyGeneralInfoProjectionFixture.java
+++ b/src/test/java/com/moyorak/api/party/domain/PartyGeneralInfoProjectionFixture.java
@@ -1,0 +1,17 @@
+package com.moyorak.api.party.domain;
+
+import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
+import java.time.LocalDateTime;
+
+public class PartyGeneralInfoProjectionFixture {
+    public static PartyGeneralInfoProjection fixture(
+            Long id,
+            LocalDateTime startDate,
+            String title,
+            VoteType voteType,
+            VoteStatus voteStatus,
+            Long attendeeCount) {
+        return new PartyGeneralInfoProjection(
+                id, startDate, title, voteType, voteStatus, attendeeCount);
+    }
+}

--- a/src/test/java/com/moyorak/api/party/domain/PartyRestaurantProjectionFixture.java
+++ b/src/test/java/com/moyorak/api/party/domain/PartyRestaurantProjectionFixture.java
@@ -1,0 +1,16 @@
+package com.moyorak.api.party.domain;
+
+import com.moyorak.api.party.dto.PartyRestaurantProjection;
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+
+public class PartyRestaurantProjectionFixture {
+    public static PartyRestaurantProjection fixture(
+            Long id,
+            String name,
+            RestaurantCategory restaurantCategory,
+            double averageReviewScore,
+            Integer reviewCount) {
+        return new PartyRestaurantProjection(
+                id, name, restaurantCategory, averageReviewScore, reviewCount);
+    }
+}

--- a/src/test/java/com/moyorak/api/party/dto/PartyListRequestFixture.java
+++ b/src/test/java/com/moyorak/api/party/dto/PartyListRequestFixture.java
@@ -1,0 +1,7 @@
+package com.moyorak.api.party.dto;
+
+public class PartyListRequestFixture {
+    public static PartyListRequest fixture(Integer size, Integer currentPage) {
+        return new PartyListRequest(size, currentPage);
+    }
+}

--- a/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
+++ b/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
@@ -4,12 +4,12 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-import com.moyorak.api.party.domain.PartyAttendee;
-import com.moyorak.api.party.domain.PartyAttendeeFixture;
+import com.moyorak.api.party.domain.PartyAttendeeWithUserFixture;
 import com.moyorak.api.party.domain.PartyGeneralInfoProjectionFixture;
 import com.moyorak.api.party.domain.PartyRestaurantProjectionFixture;
 import com.moyorak.api.party.domain.VoteStatus;
 import com.moyorak.api.party.domain.VoteType;
+import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
 import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
 import com.moyorak.api.party.dto.PartyListRequest;
 import com.moyorak.api.party.dto.PartyListRequestFixture;
@@ -72,9 +72,10 @@ class PartyFacadeTest {
             given(partyRestaurantService.findPartyRestaurantInfo(partyIds))
                     .willReturn(List.of(restaurantProjection));
 
-            final PartyAttendee attendee =
-                    PartyAttendeeFixture.fixture(partyAttendeeId, true, partyId, userId);
-            given(partyAttendeeService.findByPartyIds(partyIds)).willReturn(List.of(attendee));
+            final PartyAttendeeWithUserProfile attendee =
+                    PartyAttendeeWithUserFixture.fixture(partyId, userId, "http://test.path");
+            given(partyAttendeeService.findPartyAttendeeWithUserByPartyIds(partyIds))
+                    .willReturn(List.of(attendee));
 
             // when
             final ListResponse<PartyListResponse> result =
@@ -97,7 +98,7 @@ class PartyFacadeTest {
 
             verify(partyService).findPartyGeneralInfos(teamId);
             verify(partyRestaurantService).findPartyRestaurantInfo(partyIds);
-            verify(partyAttendeeService).findByPartyIds(partyIds);
+            verify(partyAttendeeService).findPartyAttendeeWithUserByPartyIds(partyIds);
         }
 
         @Test
@@ -107,7 +108,8 @@ class PartyFacadeTest {
             given(partyService.findPartyGeneralInfos(teamId)).willReturn(List.of());
 
             given(partyRestaurantService.findPartyRestaurantInfo(List.of())).willReturn(List.of());
-            given(partyAttendeeService.findByPartyIds(List.of())).willReturn(List.of());
+            given(partyAttendeeService.findPartyAttendeeWithUserByPartyIds(List.of()))
+                    .willReturn(List.of());
 
             // when
             final ListResponse<PartyListResponse> result =
@@ -123,7 +125,7 @@ class PartyFacadeTest {
             // 상호작용 검증
             verify(partyService).findPartyGeneralInfos(teamId);
             verify(partyRestaurantService).findPartyRestaurantInfo(List.of());
-            verify(partyAttendeeService).findByPartyIds(List.of());
+            verify(partyAttendeeService).findPartyAttendeeWithUserByPartyIds(List.of());
         }
     }
 }

--- a/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
+++ b/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
@@ -1,0 +1,129 @@
+package com.moyorak.api.party.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.moyorak.api.party.domain.PartyAttendee;
+import com.moyorak.api.party.domain.PartyAttendeeFixture;
+import com.moyorak.api.party.domain.PartyGeneralInfoProjectionFixture;
+import com.moyorak.api.party.domain.PartyRestaurantProjectionFixture;
+import com.moyorak.api.party.domain.VoteStatus;
+import com.moyorak.api.party.domain.VoteType;
+import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
+import com.moyorak.api.party.dto.PartyListRequest;
+import com.moyorak.api.party.dto.PartyListRequestFixture;
+import com.moyorak.api.party.dto.PartyListResponse;
+import com.moyorak.api.party.dto.PartyRestaurantProjection;
+import com.moyorak.api.restaurant.domain.RestaurantCategory;
+import com.moyorak.global.domain.ListResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PartyFacadeTest {
+
+    @InjectMocks private PartyFacade partyFacade;
+
+    @Mock private PartyService partyService;
+    @Mock private PartyAttendeeService partyAttendeeService;
+    @Mock private PartyRestaurantService partyRestaurantService;
+
+    @Nested
+    @DisplayName("파티 목록 조회 시")
+    class GetParties {
+
+        private final Long teamId = 1L;
+        private final Long userId = 9L;
+
+        private final PartyListRequest request = PartyListRequestFixture.fixture(5, 1);
+
+        @Test
+        @DisplayName("파티가 존재하면 정상적으로 응답한다")
+        void success() {
+            // given
+            final Long partyId = 1L;
+            final Long partyAttendeeId = 1L;
+
+            final PartyGeneralInfoProjection generalInfo =
+                    PartyGeneralInfoProjectionFixture.fixture(
+                            partyId,
+                            LocalDateTime.now(),
+                            "점심팟 구합니다.",
+                            VoteType.SELECT,
+                            VoteStatus.VOTING,
+                            3L // attendeeCount (프로젝트에서 int/Long 확인)
+                            );
+            final List<PartyGeneralInfoProjection> parties = List.of(generalInfo);
+            given(partyService.findPartyGeneralInfos(teamId)).willReturn(parties);
+
+            final List<Long> partyIds = List.of(partyId);
+
+            final PartyRestaurantProjection restaurantProjection =
+                    PartyRestaurantProjectionFixture.fixture(
+                            partyId, "음식점", RestaurantCategory.KOREAN, 5.0, 5);
+            given(partyRestaurantService.findPartyRestaurantInfo(partyIds))
+                    .willReturn(List.of(restaurantProjection));
+
+            final PartyAttendee attendee =
+                    PartyAttendeeFixture.fixture(partyAttendeeId, true, partyId, userId);
+            given(partyAttendeeService.findByPartyIds(partyIds)).willReturn(List.of(attendee));
+
+            // when
+            final ListResponse<PartyListResponse> result =
+                    partyFacade.getParties(teamId, userId, request);
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(result).isNotNull();
+                        it.assertThat(result.getData().getFirst().id()).isEqualTo(partyId);
+                        it.assertThat(
+                                        result.getData()
+                                                .getFirst()
+                                                .partyRestaurantResponseList()
+                                                .getFirst()
+                                                .name())
+                                .isEqualTo("음식점");
+                        it.assertThat(result.getData()).hasSize(1);
+                    });
+
+            verify(partyService).findPartyGeneralInfos(teamId);
+            verify(partyRestaurantService).findPartyRestaurantInfo(partyIds);
+            verify(partyAttendeeService).findByPartyIds(partyIds);
+        }
+
+        @Test
+        @DisplayName("파티가 없으면 빈 결과를 반환한다")
+        void emptyParties() {
+            // given
+            given(partyService.findPartyGeneralInfos(teamId)).willReturn(List.of());
+
+            given(partyRestaurantService.findPartyRestaurantInfo(List.of())).willReturn(List.of());
+            given(partyAttendeeService.findByPartyIds(List.of())).willReturn(List.of());
+
+            // when
+            final ListResponse<PartyListResponse> result =
+                    partyFacade.getParties(teamId, userId, request);
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(result).isNotNull();
+                        it.assertThat(result.getData()).isNotNull();
+                        it.assertThat(result.getData()).isEmpty();
+                    });
+            // 상호작용 검증
+            verify(partyService).findPartyGeneralInfos(teamId);
+            verify(partyRestaurantService).findPartyRestaurantInfo(List.of());
+            verify(partyAttendeeService).findByPartyIds(List.of());
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
- 파티 목록 조회 기능 개발

---

## 📝 코멘트
- 파티 목록 조회 기능을 개발 했습니다.
- 투표 타입이 랜덤일 때와, 선택일 때에 따라 화면에서 나와야되는 멘트가 달라야하기 때문에 타입 값을 내립니다.
- 투표 시작 시간을 내려, 투표 까지 시간은 프론트에서 구할 수 있게 했습니다.
- 본인 참가 여부를 확인하기 위해 `Boolean` 값인 `isParticipating` 를 내립니다.
- 파티에 `teamId` ,  일반 투표 정보에 `startDate` 를 추가했습니다.
