### PR TITLE
feature:#250 팟 참여자 정보 조회

### DIFF
--- a/src/main/java/com/moyorak/api/auth/repository/MealTagRepository.java
+++ b/src/main/java/com/moyorak/api/auth/repository/MealTagRepository.java
@@ -31,4 +31,10 @@ public interface MealTagRepository extends CrudRepository<MealTag, Long> {
                     name = "org.hibernate.comment",
                     value = "FoodFlagRepository.findByUserIdAndUse : 회원 ID별 등록된 항목을 조회합니다."))
     List<MealTag> findByUserIdAndUse(Long userId, boolean use);
+
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "FoodFlagRepository.findByUserIdInAndUse : 회원 ID들로 등록된 항목을 조회합니다."))
+    List<MealTag> findByUserIdInAndUse(List<Long> userIds, boolean use);
 }

--- a/src/main/java/com/moyorak/api/auth/service/MealTagService.java
+++ b/src/main/java/com/moyorak/api/auth/service/MealTagService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,5 +108,23 @@ public class MealTagService {
                             "%s 타입은 최대 %d개까지만 등록 가능합니다.",
                             type.getDescription(), MAX_ITEMS_PER_TYPE));
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Map<MealTagType, List<String>>> getMealTags(final List<Long> userIds) {
+        final List<MealTag> existingTags = mealTagRepository.findByUserIdInAndUse(userIds, true);
+
+        return existingTags.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                MealTag::getUserId,
+                                Collectors.groupingBy(
+                                        MealTag::getType,
+                                        Collectors.collectingAndThen(
+                                                Collectors.mapping(
+                                                        MealTag::getItem,
+                                                        Collectors.toCollection(
+                                                                LinkedHashSet::new)),
+                                                ArrayList::new))));
     }
 }

--- a/src/main/java/com/moyorak/api/party/controller/PartyAttendeeController.java
+++ b/src/main/java/com/moyorak/api/party/controller/PartyAttendeeController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,4 +35,10 @@ class PartyAttendeeController {
         partyAttendeeService.attend(
                 PartyAttendRequest.create(partyId, userPrincipal.getId()), teamId);
     }
+
+    @GetMapping("/teams/{teamId}/parties/{partyId}/party-attendees")
+    @Operation(summary = "[파티 참석자] 파티 참석자 조회", description = "파티 참석자를 조회 합니다.")
+    public void getPartyAttendees(
+            @PathVariable @Positive final Long partyId,
+            @PathVariable @Positive final Long teamId) {}
 }

--- a/src/main/java/com/moyorak/api/party/controller/PartyAttendeeController.java
+++ b/src/main/java/com/moyorak/api/party/controller/PartyAttendeeController.java
@@ -2,11 +2,14 @@ package com.moyorak.api.party.controller;
 
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.party.dto.PartyAttendRequest;
+import com.moyorak.api.party.dto.PartyAttendeeListResponse;
 import com.moyorak.api.party.service.PartyAttendeeService;
+import com.moyorak.api.party.service.PartyFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -23,8 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "JWT")
 @Tag(name = "[파티 참석자] 파티 참석자 API", description = "파티 참석자를 위한 API 입니다.")
 class PartyAttendeeController {
-
     private final PartyAttendeeService partyAttendeeService;
+    private final PartyFacade partyFacade;
 
     @PostMapping("/teams/{teamId}/parties/{partyId}")
     @Operation(summary = "[파티 참석자] 파티 참석", description = "파티 참석을 합니다.")
@@ -38,7 +41,8 @@ class PartyAttendeeController {
 
     @GetMapping("/teams/{teamId}/parties/{partyId}/party-attendees")
     @Operation(summary = "[파티 참석자] 파티 참석자 조회", description = "파티 참석자를 조회 합니다.")
-    public void getPartyAttendees(
-            @PathVariable @Positive final Long partyId,
-            @PathVariable @Positive final Long teamId) {}
+    public List<PartyAttendeeListResponse> getPartyAttendees(
+            @PathVariable @Positive final Long partyId, @PathVariable @Positive final Long teamId) {
+        return partyFacade.getPartyAttendees(partyId, teamId);
+    }
 }

--- a/src/main/java/com/moyorak/api/party/dto/PartyAttendeeListResponse.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyAttendeeListResponse.java
@@ -1,0 +1,29 @@
+package com.moyorak.api.party.dto;
+
+import com.moyorak.api.auth.domain.MealTagType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+
+public record PartyAttendeeListResponse(
+        @Schema(description = "유저 고유 ID", example = "1") Long userId,
+        @Schema(description = "유저 이름", example = "홍길동") String userName,
+        @Schema(description = "유저 프로필 이미지", example = "https://image.image.png")
+                String profileImage,
+        @Schema(description = "유저 비헌호,알러지 음식", example = "{DISLIKE=[파, 콩나물], ALLERGY=[땅콩]}")
+                Map<MealTagType, List<String>> mealTags) {
+
+    public static List<PartyAttendeeListResponse> fromList(
+            List<PartyAttendeeWithUserProfile> list,
+            Map<Long, Map<MealTagType, List<String>>> map) {
+        return list.stream()
+                .map(
+                        p ->
+                                (new PartyAttendeeListResponse(
+                                        p.userId(),
+                                        p.userName(),
+                                        p.userProfile(),
+                                        map.get(p.userId()))))
+                .toList();
+    }
+}

--- a/src/main/java/com/moyorak/api/party/dto/PartyAttendeeWithUserProfile.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyAttendeeWithUserProfile.java
@@ -1,3 +1,4 @@
 package com.moyorak.api.party.dto;
 
-public record PartyAttendeeWithUserProfile(Long partyId, Long userId, String userProfile) {}
+public record PartyAttendeeWithUserProfile(
+        Long partyId, Long userId, String userName, String userProfile) {}

--- a/src/main/java/com/moyorak/api/party/repository/PartyAttendeeRepository.java
+++ b/src/main/java/com/moyorak/api/party/repository/PartyAttendeeRepository.java
@@ -15,6 +15,7 @@ public interface PartyAttendeeRepository extends CrudRepository<PartyAttendee, L
 SELECT new com.moyorak.api.party.dto.PartyAttendeeWithUserProfile(
       p.partyId,
       p.userId,
+      u.name,
       u.profileImage
 )
 FROM PartyAttendee p

--- a/src/main/java/com/moyorak/api/party/service/PartyFacade.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyFacade.java
@@ -86,4 +86,7 @@ public class PartyFacade {
         return ListResponse.from(
                 PartyListResponse.toPage(partyListResponses, partyListRequest.toPageable()));
     }
+
+    @Transactional(readOnly = true)
+    public void getPartyAttendees() {}
 }

--- a/src/main/java/com/moyorak/api/party/service/PartyService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyService.java
@@ -18,11 +18,15 @@ public class PartyService {
 
     @Transactional(readOnly = true)
     public PartyInfo getPartyInfo(final Long partyId) {
-        final Party party =
-                partyRepository
-                        .findByIdAndUseTrue(partyId)
-                        .orElseThrow(() -> new BusinessException("파티가 존재하지 않습니다."));
+        final Party party = getParty(partyId);
         return PartyInfo.from(party);
+    }
+
+    @Transactional(readOnly = true)
+    public Party getParty(final Long partyId) {
+        return partyRepository
+                .findByIdAndUseTrue(partyId)
+                .orElseThrow(() -> new BusinessException("파티가 존재하지 않습니다."));
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/moyorak/api/party/domain/PartyAttendeeWithUserFixture.java
+++ b/src/test/java/com/moyorak/api/party/domain/PartyAttendeeWithUserFixture.java
@@ -4,7 +4,7 @@ import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
 
 public class PartyAttendeeWithUserFixture {
     public static PartyAttendeeWithUserProfile fixture(
-            Long partyId, Long userId, String userProfile) {
-        return new PartyAttendeeWithUserProfile(partyId, userId, userProfile);
+            Long partyId, Long userId, String userProfile, String userName) {
+        return new PartyAttendeeWithUserProfile(partyId, userId, userName, userProfile);
     }
 }

--- a/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
+++ b/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
@@ -43,6 +43,7 @@ class PartyFacadeTest {
 
         private final Long teamId = 1L;
         private final Long userId = 9L;
+        private final String userName = "홍길동";
 
         private final PartyListRequest request = PartyListRequestFixture.fixture(5, 1);
 
@@ -73,7 +74,8 @@ class PartyFacadeTest {
                     .willReturn(List.of(restaurantProjection));
 
             final PartyAttendeeWithUserProfile attendee =
-                    PartyAttendeeWithUserFixture.fixture(partyId, userId, "http://test.path");
+                    PartyAttendeeWithUserFixture.fixture(
+                            partyId, userId, userName, "http://test.path");
             given(partyAttendeeService.findPartyAttendeeWithUserByPartyIds(partyIds))
                     .willReturn(List.of(attendee));
 

--- a/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
+++ b/src/test/java/com/moyorak/api/party/service/PartyFacadeTest.java
@@ -1,14 +1,19 @@
 package com.moyorak.api.party.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+import com.moyorak.api.auth.service.MealTagService;
+import com.moyorak.api.party.domain.Party;
 import com.moyorak.api.party.domain.PartyAttendeeWithUserFixture;
+import com.moyorak.api.party.domain.PartyFixture;
 import com.moyorak.api.party.domain.PartyGeneralInfoProjectionFixture;
 import com.moyorak.api.party.domain.PartyRestaurantProjectionFixture;
 import com.moyorak.api.party.domain.VoteStatus;
 import com.moyorak.api.party.domain.VoteType;
+import com.moyorak.api.party.dto.PartyAttendeeListResponse;
 import com.moyorak.api.party.dto.PartyAttendeeWithUserProfile;
 import com.moyorak.api.party.dto.PartyGeneralInfoProjection;
 import com.moyorak.api.party.dto.PartyListRequest;
@@ -16,8 +21,10 @@ import com.moyorak.api.party.dto.PartyListRequestFixture;
 import com.moyorak.api.party.dto.PartyListResponse;
 import com.moyorak.api.party.dto.PartyRestaurantProjection;
 import com.moyorak.api.restaurant.domain.RestaurantCategory;
+import com.moyorak.config.exception.BusinessException;
 import com.moyorak.global.domain.ListResponse;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +43,7 @@ class PartyFacadeTest {
     @Mock private PartyAttendeeService partyAttendeeService;
     @Mock private PartyRestaurantService partyRestaurantService;
     @Mock private VoteService voteService;
+    @Mock private MealTagService mealTagService;
 
     @Nested
     @DisplayName("파티 목록 조회 시")
@@ -129,6 +137,101 @@ class PartyFacadeTest {
             verify(partyService).findPartyGeneralInfos(teamId);
             verify(partyRestaurantService).findPartyRestaurantInfo(List.of());
             verify(partyAttendeeService).findPartyAttendeeWithUserByPartyIds(List.of());
+        }
+    }
+
+    @Nested
+    @DisplayName("파티 참가자 조회 시")
+    class GetPartyAttendees {
+
+        private final Long partyId = 10L;
+        private final Long teamId = 1L;
+        private final Long userId = 9L;
+        private final String userName = "홍길동";
+
+        private final PartyListRequest request = PartyListRequestFixture.fixture(5, 1);
+
+        @Test
+        @DisplayName("팀이 일치하고, 참가자가 존재하면 정상적으로 응답한다")
+        void successWhenAttendeesExist() {
+            // given
+            final Party party = PartyFixture.fixture(partyId, teamId);
+            given(party.getTeamId()).willReturn(teamId);
+            given(partyService.getParty(partyId)).willReturn(party);
+
+            final PartyAttendeeWithUserProfile attendee =
+                    PartyAttendeeWithUserFixture.fixture(
+                            partyId, userId, userName, "http://test.path");
+
+            given(partyAttendeeService.findPartyAttendeeWithUserByPartyIds(List.of(partyId)))
+                    .willReturn(List.of(attendee));
+
+            given(mealTagService.getMealTags(List.of(userId))).willReturn(Collections.emptyMap());
+
+            // when
+            final List<PartyAttendeeListResponse> result =
+                    partyFacade.getPartyAttendees(partyId, teamId);
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(result).isNotNull();
+                        it.assertThat(result).hasSize(1);
+                    });
+
+            verify(partyService).getParty(partyId);
+            verify(partyAttendeeService).findPartyAttendeeWithUserByPartyIds(List.of(partyId));
+            verify(mealTagService).getMealTags(List.of(userId));
+            verifyNoMoreInteractions(partyService, partyAttendeeService, mealTagService);
+        }
+
+        @Test
+        @DisplayName("해당 팀의 파티가 아니면 예외를 던진다")
+        void failWhenTeamMismatch() {
+            // given
+            final Party party = PartyFixture.fixture(partyId, teamId);
+            given(party.getTeamId()).willReturn(999L);
+            given(partyService.getParty(partyId)).willReturn(party);
+
+            // when & then
+            assertThatThrownBy(() -> partyFacade.getPartyAttendees(partyId, teamId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("해당 팀의 파티가 아닙니다.");
+
+            verify(partyService).getParty(partyId);
+            verifyNoInteractions(partyAttendeeService);
+            verifyNoInteractions(mealTagService);
+        }
+
+        @Test
+        @DisplayName("참가자가 없으면 빈 리스트로 응답한다")
+        void successWhenNoAttendees() {
+            // given
+            final Party party = PartyFixture.fixture(partyId, teamId);
+            given(party.getTeamId()).willReturn(teamId);
+            given(partyService.getParty(partyId)).willReturn(party);
+
+            given(partyAttendeeService.findPartyAttendeeWithUserByPartyIds(List.of(partyId)))
+                    .willReturn(Collections.emptyList());
+
+            given(mealTagService.getMealTags(Collections.emptyList()))
+                    .willReturn(Collections.emptyMap());
+
+            // when
+            final List<PartyAttendeeListResponse> result =
+                    partyFacade.getPartyAttendees(partyId, teamId);
+
+            // then
+            assertSoftly(
+                    it -> {
+                        it.assertThat(result).isNotNull();
+                        it.assertThat(result).isEmpty();
+                    });
+
+            verify(partyService).getParty(partyId);
+            verify(partyAttendeeService).findPartyAttendeeWithUserByPartyIds(List.of(partyId));
+            verify(mealTagService).getMealTags(Collections.emptyList());
+            verifyNoMoreInteractions(partyService, partyAttendeeService, mealTagService);
         }
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팟 참여자 정보 조회 기능 개발
---

## 📝 코멘트
- 인원 조회에 페이징 적용 까지 필요하지 않을 것 같아 리스트로 내리도록 만들었습니다.
- 클라이언트에서 바로 뿌릴 수 있도록, 비선호, 알러지 를 키로 가진 맵을 내리도록 만들었습니다. 
