### PR TITLE
refactor: #272 파티 생성시, 투표 상세 정보도 함께 저장도록 기능 추가

### DIFF
--- a/src/main/java/com/moyorak/api/party/domain/RandomVoteInfo.java
+++ b/src/main/java/com/moyorak/api/party/domain/RandomVoteInfo.java
@@ -9,13 +9,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 @Getter
 @Entity
 @Table(name = "random_vote_info")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RandomVoteInfo extends AuditInformation {
 
     @Id
@@ -43,6 +49,29 @@ public class RandomVoteInfo extends AuditInformation {
     @Convert(converter = BooleanYnConverter.class)
     @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
     private boolean use = true;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private RandomVoteInfo(
+            LocalDateTime randomDate,
+            LocalDateTime mealDate,
+            Long voteId,
+            Long selectedCandidateId,
+            boolean use) {
+        this.randomDate = randomDate;
+        this.mealDate = mealDate;
+        this.voteId = voteId;
+        this.selectedCandidateId = selectedCandidateId;
+        this.use = use;
+    }
+
+    public static RandomVoteInfo generate(
+            final Long voteId, final LocalDate date, final LocalTime randomDate) {
+        return RandomVoteInfo.builder()
+                .voteId(voteId)
+                .randomDate(LocalDateTime.of(date, randomDate))
+                .use(true)
+                .build();
+    }
 
     public void confirmRandomCandidate(final Long candidateId) {
         selectedCandidateId = candidateId;

--- a/src/main/java/com/moyorak/api/party/domain/SelectionVoteInfo.java
+++ b/src/main/java/com/moyorak/api/party/domain/SelectionVoteInfo.java
@@ -9,8 +9,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -46,4 +49,33 @@ public class SelectionVoteInfo extends AuditInformation {
     @Convert(converter = BooleanYnConverter.class)
     @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")
     private boolean use = true;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private SelectionVoteInfo(
+            LocalDateTime startDate,
+            LocalDateTime expiredDate,
+            LocalDateTime mealDate,
+            Long voteId,
+            boolean use) {
+        this.startDate = startDate;
+        this.expiredDate = expiredDate;
+        this.mealDate = mealDate;
+        this.voteId = voteId;
+        this.use = use;
+    }
+
+    public static SelectionVoteInfo generate(
+            final Long voteId,
+            final LocalDate date,
+            final LocalTime startDate,
+            final LocalTime expiredDate,
+            final LocalTime mealDate) {
+        return SelectionVoteInfo.builder()
+                .voteId(voteId)
+                .startDate(LocalDateTime.of(date, startDate))
+                .expiredDate(LocalDateTime.of(date, expiredDate))
+                .mealDate(LocalDateTime.of(date, mealDate))
+                .use(true)
+                .build();
+    }
 }

--- a/src/main/java/com/moyorak/api/party/dto/PartySaveRequest.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartySaveRequest.java
@@ -1,10 +1,12 @@
 package com.moyorak.api.party.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.moyorak.api.party.domain.VoteType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +30,27 @@ public class PartySaveRequest {
     @Schema(description = "파티 설명", example = "국밥 빼고 다 좋아하는 파티입니다.")
     private String content;
 
+    @JsonIgnore
+    public boolean isVoteTypeSelect() {
+        return getVoteType().isSelect();
+    }
+
     public VoteType getVoteType() {
         return vote.getVoteType();
+    }
+
+    @JsonIgnore
+    public LocalTime getVoteStartTime() {
+        return vote.getFromTime();
+    }
+
+    @JsonIgnore
+    public LocalTime getVoteEndTime() {
+        return vote.getToTime();
+    }
+
+    @JsonIgnore
+    public LocalTime getPartyMealTime() {
+        return vote.getMealTime();
     }
 }

--- a/src/main/java/com/moyorak/api/party/service/PartyFacade.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyFacade.java
@@ -115,7 +115,7 @@ public class PartyFacade {
                 partyService.register(teamId, request.getTitle(), request.getContent());
 
         // 3. 투표 생성
-        final Long voteId = voteService.register(partyId, request.getVoteType());
+        final Long voteId = voteService.register(partyId, request);
 
         // 4. 파티 회원 등록
         partyAttendeeService.registerUsers(partyId, request.getUserSelections().getUsers());

--- a/src/main/java/com/moyorak/api/party/service/VoteService.java
+++ b/src/main/java/com/moyorak/api/party/service/VoteService.java
@@ -4,7 +4,7 @@ import com.moyorak.api.party.domain.RandomVoteInfo;
 import com.moyorak.api.party.domain.SelectionVoteInfo;
 import com.moyorak.api.party.domain.Vote;
 import com.moyorak.api.party.domain.VoteRestaurantCandidate;
-import com.moyorak.api.party.domain.VoteType;
+import com.moyorak.api.party.dto.PartySaveRequest;
 import com.moyorak.api.party.dto.VoteDetail;
 import com.moyorak.api.party.dto.VoteInfo;
 import com.moyorak.api.party.repository.PartyRestaurantRepository;
@@ -12,6 +12,7 @@ import com.moyorak.api.party.repository.RandomVoteInfoRepository;
 import com.moyorak.api.party.repository.SelectionVoteInfoRepository;
 import com.moyorak.api.party.repository.VoteRepository;
 import com.moyorak.config.exception.BusinessException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -127,11 +128,30 @@ public class VoteService {
      * 투표를 생성합니다.
      *
      * @param partyId 파티 고유 ID
-     * @param voteType 파티 타입
+     * @param request 파티 생성 요청 DTO
      * @return 투표 고유 ID
      */
     @Transactional
-    public Long register(final Long partyId, final VoteType voteType) {
-        return voteRepository.save(Vote.create(partyId, voteType)).getId();
+    public Long register(final Long partyId, final PartySaveRequest request) {
+        final Vote vote = voteRepository.save(Vote.create(partyId, request.getVoteType()));
+
+        final LocalDate now = LocalDate.now();
+
+        if (request.isVoteTypeSelect()) {
+            selectionVoteInfoRepository.save(
+                    SelectionVoteInfo.generate(
+                            vote.getId(),
+                            now,
+                            request.getVoteStartTime(),
+                            request.getVoteEndTime(),
+                            request.getPartyMealTime()));
+
+            return vote.getId();
+        }
+
+        randomVoteInfoRepository.save(
+                RandomVoteInfo.generate(vote.getId(), now, request.getVoteEndTime()));
+
+        return vote.getId();
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 파티 생성하고 목록 조회가 되지 않는다고 하여, 저장할 때 투표 상세 정보도 함께 저장할 수 있도록 추가 하였습니다.

---

## 📝 코멘트
- 파티 생성시, 투표 상세 정보도 함께 저장도록 기능 추가