### PR TITLE
refactor: #278 파티 참여 시 참여 가능 여부 검증 추가

### DIFF
--- a/src/main/java/com/moyorak/api/party/domain/Party.java
+++ b/src/main/java/com/moyorak/api/party/domain/Party.java
@@ -37,6 +37,11 @@ public class Party extends AuditInformation {
     @Column(name = "content", nullable = false, columnDefinition = "varchar(512)")
     private String content;
 
+    @Comment("파티 참여 가능 여부")
+    @Convert(converter = BooleanYnConverter.class)
+    @Column(name = "attendable", nullable = false, columnDefinition = "char(1)")
+    private boolean attendable;
+
     @Comment("사용 여부")
     @Convert(converter = BooleanYnConverter.class)
     @Column(name = "use_yn", nullable = false, columnDefinition = "char(1)")

--- a/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
@@ -52,6 +52,10 @@ public class PartyAttendeeService {
                         .findByIdAndUseTrue(request.partyId())
                         .orElseThrow(() -> new BusinessException("파티가 존재하지 않습니다."));
 
+        if (!party.isAttendable()) {
+            throw new BusinessException("참석 불가능한 파티입니다.");
+        }
+
         validateSameTeam(teamUser, party);
 
         final PartyAttendee partyAttendee = request.toPartyAttendee();

--- a/src/test/java/com/moyorak/api/party/domain/PartyFixture.java
+++ b/src/test/java/com/moyorak/api/party/domain/PartyFixture.java
@@ -3,6 +3,16 @@ package com.moyorak.api.party.domain;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class PartyFixture {
+    public static Party fixture(final Long id, final Long teamId, final boolean attendable) {
+        Party party = new Party();
+
+        ReflectionTestUtils.setField(party, "id", id);
+        ReflectionTestUtils.setField(party, "teamId", teamId);
+        ReflectionTestUtils.setField(party, "attendable", attendable);
+
+        return party;
+    }
+
     public static Party fixture(final Long id, final Long teamId) {
         Party party = new Party();
 

--- a/src/test/java/com/moyorak/api/party/service/PartyAttendeeServiceTest.java
+++ b/src/test/java/com/moyorak/api/party/service/PartyAttendeeServiceTest.java
@@ -73,7 +73,7 @@ class PartyAttendeeServiceTest {
             final Team requesterTeam = TeamFixture.fixture(teamId, true);
             final TeamUser requesterTeamUser =
                     TeamUserFixture.fixture(userId, requesterTeam, TeamUserStatus.APPROVED, true);
-            final Party party = PartyFixture.fixture(partyId, otherTeamId);
+            final Party party = PartyFixture.fixture(partyId, otherTeamId, true);
 
             given(partyAttendeeRepository.findByPartyIdAndUserIdAndUseTrue(partyId, userId))
                     .willReturn(Optional.empty());


### PR DESCRIPTION
## 📌 주요 변경 사항
- 파티 엔티티에 참석 가능 여부 필드 추가
- 파티 참여 시 참여 가능 여부 검증 추가

---

## 📝 코멘트
파티 참여 가능 여부 기능에 맞춰서 엔티티에 필드를 추가하고 검증 로직을 추가했습니다.
