### PR TITLE
refactor: #279 파티 상세 조회 시 응답 dto 필드에 참여 가능 여부 필드 추가

### DIFF
--- a/src/main/java/com/moyorak/api/party/controller/PartyController.java
+++ b/src/main/java/com/moyorak/api/party/controller/PartyController.java
@@ -40,7 +40,7 @@ class PartyController {
             @PathVariable @Positive final Long teamId,
             @PathVariable @Positive final Long partyId,
             @AuthenticationPrincipal final UserPrincipal userPrincipal) {
-        return partyFacade.getParty(partyId, userPrincipal.getId());
+        return partyFacade.getParty(partyId, teamId, userPrincipal.getId());
     }
 
     @GetMapping("/teams/{teamId}/parties")

--- a/src/main/java/com/moyorak/api/party/domain/Party.java
+++ b/src/main/java/com/moyorak/api/party/domain/Party.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +54,10 @@ public class Party extends AuditInformation {
         this.title = title;
         this.content = content;
         this.use = use;
+    }
+
+    public boolean isSameTeam(final Long teamId) {
+        return Objects.equals(this.teamId, teamId);
     }
 
     public static Party create(final Long teamId, final String title, final String content) {

--- a/src/main/java/com/moyorak/api/party/dto/PartyInfo.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyInfo.java
@@ -2,8 +2,9 @@ package com.moyorak.api.party.dto;
 
 import com.moyorak.api.party.domain.Party;
 
-public record PartyInfo(Long id, String title, String content) {
+public record PartyInfo(Long id, String title, String content, boolean attendable) {
     public static PartyInfo from(final Party party) {
-        return new PartyInfo(party.getId(), party.getTitle(), party.getContent());
+        return new PartyInfo(
+                party.getId(), party.getTitle(), party.getContent(), party.isAttendable());
     }
 }

--- a/src/main/java/com/moyorak/api/party/dto/PartyResponse.java
+++ b/src/main/java/com/moyorak/api/party/dto/PartyResponse.java
@@ -9,6 +9,7 @@ public record PartyResponse(
         @Schema(description = "파티 고유 ID", example = "1") Long id,
         @Schema(description = "파티 제목", example = "분식 가실 분") String title,
         @Schema(description = "파티 내용", example = "3개 음식점 중에 골라보시죠") String content,
+        @Schema(description = "파티 참석 가능 여부", example = "true") boolean attendable,
         @Schema(description = "투표 정보") VoteResponse vote,
         @ArraySchema(
                         schema = @Schema(implementation = RestaurantCandidateResponse.class),
@@ -33,6 +34,7 @@ public record PartyResponse(
                 partyInfo.id(),
                 partyInfo.title(),
                 partyInfo.content(),
+                partyInfo.attendable(),
                 VoteResponse.from(voteInfo),
                 candidates,
                 voterResponses,

--- a/src/main/java/com/moyorak/api/party/service/PartyFacade.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyFacade.java
@@ -49,10 +49,10 @@ public class PartyFacade {
     private final UserService userService;
 
     @Transactional
-    public PartyResponse getParty(final Long partyId, final Long userId) {
+    public PartyResponse getParty(final Long partyId, final Long teamId, final Long userId) {
 
         // 파티 정보 가져오기
-        final PartyInfo partyInfo = partyService.getPartyInfo(partyId);
+        final PartyInfo partyInfo = partyService.getPartyInfo(partyId, teamId);
 
         // 투표 정보 가져오기
         final VoteDetail voteDetail = voteService.getVoteDetail(partyId, LocalDateTime.now());

--- a/src/main/java/com/moyorak/api/party/service/PartyService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyService.java
@@ -17,8 +17,11 @@ public class PartyService {
     private final PartyRepository partyRepository;
 
     @Transactional(readOnly = true)
-    public PartyInfo getPartyInfo(final Long partyId) {
+    public PartyInfo getPartyInfo(final Long partyId, final Long teamId) {
         final Party party = getParty(partyId);
+        if (!party.isSameTeam(teamId)) {
+            throw new BusinessException("팀에 해당 파티가 존재하지 않습니다.");
+        }
         return PartyInfo.from(party);
     }
 


### PR DESCRIPTION
## 📌 주요 변경 사항
- 응답 dto에 해당 파티가 참석 가능한 파티인지 확인하는 필드 추가
- 팀에 해당하는 파티인지 검증하는 로직 추가

---

## 📝 코멘트
dto에 참석 가능한 파티인지 확인하는 필드를 추가하고,
해당 파티가 팀에 속하는지 검증 로직을 추가합니다. 
