### PR TITLE
fix:#284 팀 맛집 리뷰 업데이트 쿼리 수정,리뷰 업데이트 시 이미지 수정 로직 변경

### DIFF
--- a/src/main/java/com/moyorak/api/team/repository/TeamRestaurantRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamRestaurantRepository.java
@@ -57,17 +57,29 @@ WHERE tr.id IN :ids AND tr.use = :use
     @Modifying(clearAutomatically = true)
     @Query(
             """
-UPDATE TeamRestaurant tr
-SET
-    tr.reviewCount = tr.reviewCount + :reviewCount,
-    tr.totalReviewScore = tr.totalReviewScore -:previousReviewScore + :reviewScore,
-    tr.totalServingTime = tr.totalServingTime -:previousServingTime + :servingTime,
-    tr.totalWaitingTime = tr.totalWaitingTime -:previousWaitingTime + :waitingTime,
-    tr.averageReviewScore = ROUND((tr.totalReviewScore -:previousReviewScore + :reviewScore) * 1.0 / (tr.reviewCount + :reviewCount), 1),
-    tr.averageServingTime = ROUND((tr.totalServingTime -:previousServingTime + :servingTime) * 1.0 / (tr.reviewCount + :reviewCount), 1),
-    tr.averageWaitingTime = ROUND((tr.totalWaitingTime -:previousWaitingTime + :waitingTime) * 1.0 / (tr.reviewCount + :reviewCount), 1)
-WHERE tr.id = :teamRestaurantId
-""")
+        UPDATE TeamRestaurant tr
+        SET
+            tr.reviewCount = tr.reviewCount + :reviewCount,
+            tr.totalReviewScore = tr.totalReviewScore - :previousReviewScore + :reviewScore,
+            tr.totalServingTime = tr.totalServingTime - :previousServingTime + :servingTime,
+            tr.totalWaitingTime = tr.totalWaitingTime - :previousWaitingTime + :waitingTime,
+
+            tr.averageReviewScore = CASE
+                WHEN tr.reviewCount = 0 THEN 0
+                ELSE ROUND((tr.totalReviewScore - :previousReviewScore + :reviewScore) * 1.0 / tr.reviewCount, 1)
+            END,
+
+            tr.averageServingTime = CASE
+                WHEN tr.reviewCount = 0 THEN 0
+                ELSE ROUND((tr.totalServingTime - :previousServingTime + :servingTime) * 1.0 / tr.reviewCount, 1)
+            END,
+
+            tr.averageWaitingTime = CASE
+                WHEN tr.reviewCount = 0 THEN 0
+                ELSE ROUND((tr.totalWaitingTime - :previousWaitingTime + :waitingTime) * 1.0 / tr.reviewCount, 1)
+            END
+        WHERE tr.id = :teamRestaurantId
+        """)
     @QueryHints(
             @QueryHint(
                     name = "org.hibernate.comment",


### PR DESCRIPTION
## 📌 주요 변경 사항
- 리뷰 수정 시, 빠진 이미지 제거, 새로운 이미지 추가
- 팀 맛집 정보 리뷰 값 업데이트 후, 리뷰 업데이트
- 팀 맛집 정보 업데이트 쿼리 변경

---

## 📝 코멘트
- 쿼리에서, `reviewCount` 값이 증감되어 사용되어, 해당 사항 변경
- 리뷰 값이 업데이트 된 상태에서 팀 맛집 값을 변경해, 변경사항이 반영되지 않아 수정
- 이미지 업데이트 로직 변경