### PR TITLE
fix:#284 리뷰, 리뷰사진 조회 트랜잭션 변경, 팀 맛집 정보 음수 되지 못하게 변경

### DIFF
--- a/src/main/java/com/moyorak/api/review/service/ReviewFacade.java
+++ b/src/main/java/com/moyorak/api/review/service/ReviewFacade.java
@@ -75,7 +75,7 @@ public class ReviewFacade {
         // 유효성 체크
         teamRestaurantService.getValidatedTeamRestaurant(teamId, teamRestaurantId);
 
-        Review review = reviewService.getReview(reviewId);
+        Review review = reviewService.getReviewForUpdate(reviewId);
 
         if (!review.isMine(userId)) {
             throw new BusinessException("본인 리뷰가 아닙니다.");
@@ -143,7 +143,7 @@ public class ReviewFacade {
             final Long userId) {
         // 유효성 체크
         teamRestaurantService.getValidatedTeamRestaurant(teamId, teamRestaurantId);
-        Review review = reviewService.getReview(reviewId);
+        Review review = reviewService.getReviewForUpdate(reviewId);
 
         if (!review.isMine(userId)) {
             throw new BusinessException("본인 리뷰가 아닙니다.");

--- a/src/main/java/com/moyorak/api/review/service/ReviewPhotoService.java
+++ b/src/main/java/com/moyorak/api/review/service/ReviewPhotoService.java
@@ -48,7 +48,7 @@ public class ReviewPhotoService {
         return reviewPhotoRepository.findPhotoPathsByReviewIds(reviewIds);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public List<ReviewPhoto> getReviewPhotosByReviewId(final Long reviewId) {
         return reviewPhotoRepository.findReviewPhotosByReviewIdAndUseIsTrue(reviewId);
     }

--- a/src/main/java/com/moyorak/api/review/service/ReviewService.java
+++ b/src/main/java/com/moyorak/api/review/service/ReviewService.java
@@ -83,8 +83,8 @@ public class ReviewService {
                 reviewSaveRequest.toReview(servingTimeValue, waitingTimeValue, teamRestaurantId));
     }
 
-    @Transactional(readOnly = true)
-    public Review getReview(final Long id) {
+    @Transactional
+    public Review getReviewForUpdate(final Long id) {
         return reviewRepository
                 .findByIdAndUseIsTrue(id)
                 .orElseThrow(() -> new BusinessException("리뷰가 존재하지 않습니다."));

--- a/src/main/java/com/moyorak/api/team/repository/TeamRestaurantRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamRestaurantRepository.java
@@ -59,7 +59,7 @@ WHERE tr.id IN :ids AND tr.use = :use
             """
         UPDATE TeamRestaurant tr
         SET
-            tr.reviewCount = tr.reviewCount + :reviewCount,
+            tr.reviewCount = CASE WHEN tr.reviewCount + :reviewCount <= 0 THEN 0 ELSE tr.reviewCount + :reviewCount END,
             tr.totalReviewScore = tr.totalReviewScore - :previousReviewScore + :reviewScore,
             tr.totalServingTime = tr.totalServingTime - :previousServingTime + :servingTime,
             tr.totalWaitingTime = tr.totalWaitingTime - :previousWaitingTime + :waitingTime,

--- a/src/test/java/com/moyorak/api/review/service/ReviewFacadeTest.java
+++ b/src/test/java/com/moyorak/api/review/service/ReviewFacadeTest.java
@@ -189,7 +189,7 @@ class ReviewFacadeTest {
 
         given(teamRestaurantService.getValidatedTeamRestaurant(teamId, teamRestaurantId))
                 .willReturn(teamRestaurant);
-        given(reviewService.getReview(reviewId)).willReturn(review);
+        given(reviewService.getReviewForUpdate(reviewId)).willReturn(review);
         given(reviewService.getReviewServingTime(request.servingTimeId())).willReturn(servingTime);
         given(reviewService.getReviewWaitingTime(request.waitingTimeId())).willReturn(waitingTime);
         given(reviewPhotoService.getReviewPhotosByReviewId(reviewId)).willReturn(existingPhotos);
@@ -198,7 +198,7 @@ class ReviewFacadeTest {
         reviewFacade.updateReview(teamId, teamRestaurantId, reviewId, request, userId);
 
         // then
-        verify(reviewService).getReview(reviewId);
+        verify(reviewService).getReviewForUpdate(reviewId);
 
         verify(reviewPhotoService)
                 .createReviewPhoto(List.of("s3://new1.jpg", "s3://new2.jpg"), reviewId);
@@ -266,7 +266,7 @@ class ReviewFacadeTest {
 
         given(teamRestaurantService.getValidatedTeamRestaurant(teamId, teamRestaurantId))
                 .willReturn(teamRestaurant);
-        given(reviewService.getReview(reviewId)).willReturn(review);
+        given(reviewService.getReviewForUpdate(reviewId)).willReturn(review);
         given(reviewPhotoService.getReviewPhotosByReviewId(reviewId)).willReturn(reviewPhotos);
 
         // when
@@ -275,7 +275,7 @@ class ReviewFacadeTest {
         // then
         verify(teamRestaurantService, times(2))
                 .getValidatedTeamRestaurant(teamId, teamRestaurantId);
-        verify(reviewService).getReview(reviewId);
+        verify(reviewService).getReviewForUpdate(reviewId);
         verify(reviewPhotoService).getReviewPhotosByReviewId(reviewId);
 
         verify(teamRestaurantService)


### PR DESCRIPTION
## 📌 주요 변경 사항
- 리뷰, 리뷰사진 조회 트랜잭션 변경
- 팀 맛집 정보 음수 되지 못하게 변경

---

## 📝 코멘트
- `readonly=True`로 저장이 되지 않아, 변경
- 팀 맛집 정보가 0 보다 작아지지 못하게 조건 문 설정
