### PR TITLE
fix:#284 벌크 업데이트 전 flush되게 변경

### DIFF
--- a/src/main/java/com/moyorak/api/review/service/ReviewFacade.java
+++ b/src/main/java/com/moyorak/api/review/service/ReviewFacade.java
@@ -110,23 +110,26 @@ public class ReviewFacade {
         // 기존 사진 삭제
         toDeactivate.forEach(ReviewPhoto::toggleUse);
 
-        // 팀 맛집 평균 값 수정
-        teamRestaurantService.updateAverageValue(
-                0,
-                teamRestaurantId,
-                review.getScore(),
-                reviewUpdateRequest.score(),
-                review.getServingTime(),
-                reviewServingTime.getServingTimeValue(),
-                review.getWaitingTime(),
-                reviewWaitingTime.getWaitingTimeValue());
-
-        // 팀 맛집 데이터 업데이트 후 리뷰 업데이트
+        final Integer reviewScore = review.getScore();
+        final Integer servingTime = review.getServingTime();
+        final Integer waitingTime = review.getWaitingTime();
+        // 리뷰 업데이트
         review.updateReview(
                 reviewUpdateRequest.extraText(),
                 reviewServingTime.getServingTimeValue(),
                 reviewWaitingTime.getWaitingTimeValue(),
                 reviewUpdateRequest.score());
+
+        // 팀 맛집 평균 값 수정
+        teamRestaurantService.updateAverageValue(
+                0,
+                teamRestaurantId,
+                reviewScore,
+                reviewUpdateRequest.score(),
+                servingTime,
+                reviewServingTime.getServingTimeValue(),
+                waitingTime,
+                reviewWaitingTime.getWaitingTimeValue());
 
         // 업데이트 된 정보 조히 및 검색 테이블에 저장
         final TeamRestaurant updatedTeamRestaurant =

--- a/src/main/java/com/moyorak/api/team/repository/TeamRestaurantRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamRestaurantRepository.java
@@ -54,7 +54,7 @@ WHERE tr.id IN :ids AND tr.use = :use
 
     Page<TeamRestaurant> findAllByTeamId(Long teamId, Pageable pageable);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             """
         UPDATE TeamRestaurant tr


### PR DESCRIPTION
## 📌 주요 변경 사항
- 벌크 업데이트 전 flush되게 변경

---

## 📝 코멘트
- 벌크 업데이트 이전에 있던 영속성 캐시 다 날려 저장이 안돼서 설정 변경
