### PR TITLE
chore: #294 도커파일 JVM 타임존 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN ./gradlew bootJar -Djava-profiles-active=dev
 
 FROM eclipse-temurin:21-jre-alpine
 COPY --from=builder /app/build/libs/ddd-12-moyorak-api-0.0.1-SNAPSHOT.jar moyorak-application.jar
-ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=70", "-jar", "/moyorak-application.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=70", "-Duser.timezone=Asia/Seoul", "-jar", "/moyorak-application.jar"]


### PR DESCRIPTION
## 📌 주요 변경 사항
- 도커 컨테이너 타임존 설정이 되지않아 시간 설정의 차이가 있어, 도커파일 내의 JVM 타임존 설정 추가하였습니다.

---

## 📝 코멘트
- 도커파일 JVM 타임존 설정 추가