### PR TITLE
feat: #296 로그인 정보로 회원의 회사, 팀 ID를 조회하는 API 추가

### DIFF
--- a/src/main/java/com/moyorak/api/auth/controller/UserController.java
+++ b/src/main/java/com/moyorak/api/auth/controller/UserController.java
@@ -3,6 +3,7 @@ package com.moyorak.api.auth.controller;
 import com.moyorak.api.auth.domain.UserPrincipal;
 import com.moyorak.api.auth.dto.SignUpRequest;
 import com.moyorak.api.auth.dto.SignUpResponse;
+import com.moyorak.api.auth.dto.UserOrganisationResponse;
 import com.moyorak.api.auth.service.UserFacade;
 import com.moyorak.api.auth.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,5 +53,22 @@ class UserController {
             description = "회원 탈퇴를 요청합니다.\n이름과 생년월일, 성별, 알러지 + 비선호 음식, 회사, 팀 정보가 제거 됩니다.")
     public void unregister(@AuthenticationPrincipal final UserPrincipal userPrincipal) {
         userFacade.unregister(userPrincipal.getId());
+    }
+
+    @GetMapping
+    @SecurityRequirement(name = "JWT")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "조회 성공"),
+                @ApiResponse(
+                        responseCode = "400",
+                        description =
+                                "<ol><li>회원 정보가 없는 경우</li><li>로그인 정보가 없는 경우</li><li>예상치 못한 클라이언트 오류</li></ol>"),
+                @ApiResponse(responseCode = "401", description = "로그인 정보가 없는 경우"),
+                @ApiResponse(responseCode = "500", description = "예상치 못한 서버 오류"),
+            })
+    @Operation(summary = "[회원] [마이] 회사, 팀 ID 조회", description = "로그인 된 정보에 의해 회사와 팀 ID를 조회합니다.")
+    public UserOrganisationResponse me(@AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        return userFacade.getMe(userPrincipal.getId());
     }
 }

--- a/src/main/java/com/moyorak/api/auth/dto/UserOrganisationResponse.java
+++ b/src/main/java/com/moyorak/api/auth/dto/UserOrganisationResponse.java
@@ -1,0 +1,13 @@
+package com.moyorak.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "[회원] 회원 소속 정보 응답 DTO")
+public record UserOrganisationResponse(
+        @Schema(description = "회사 고유 ID", example = "1") Long companyId,
+        @Schema(description = "팀 고유 ID", example = "1") Long teamId) {
+
+    public static UserOrganisationResponse from(final Long companyId, final Long teamId) {
+        return new UserOrganisationResponse(companyId, teamId);
+    }
+}

--- a/src/main/java/com/moyorak/api/auth/service/UserFacade.java
+++ b/src/main/java/com/moyorak/api/auth/service/UserFacade.java
@@ -1,5 +1,6 @@
 package com.moyorak.api.auth.service;
 
+import com.moyorak.api.auth.dto.UserOrganisationResponse;
 import com.moyorak.api.team.service.TeamUserService;
 import com.moyorak.config.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +49,16 @@ public class UserFacade {
 
         // 5. 토큰 초기화
         authService.signOut(userId);
+    }
+
+    /**
+     * 입력된 ID의 회사, 팀 ID를 조회합니다.
+     *
+     * @param userId 회원 고유 ID
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public UserOrganisationResponse getMe(final Long userId) {
+        return teamUserService.getTeamId(userId);
     }
 }

--- a/src/main/java/com/moyorak/api/team/domain/Team.java
+++ b/src/main/java/com/moyorak/api/team/domain/Team.java
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.springframework.util.ObjectUtils;
 
 @Getter
 @Entity
@@ -52,5 +53,13 @@ public class Team extends AuditInformation {
 
     public static Team create(final String name, final Company company) {
         return Team.builder().name(name).use(true).company(company).build();
+    }
+
+    public Long getCompanyId() {
+        if (ObjectUtils.isEmpty(company)) {
+            return null;
+        }
+
+        return company.getId();
     }
 }

--- a/src/main/java/com/moyorak/api/team/domain/TeamUser.java
+++ b/src/main/java/com/moyorak/api/team/domain/TeamUser.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.springframework.util.ObjectUtils;
 
 @Getter
 @Entity
@@ -131,5 +132,13 @@ public class TeamUser extends AuditInformation {
         teamUser.status = teamUserStatus;
 
         return teamUser;
+    }
+
+    public Long getTeamId() {
+        if (ObjectUtils.isEmpty(team)) {
+            return null;
+        }
+
+        return team.getId();
     }
 }

--- a/src/main/java/com/moyorak/api/team/repository/TeamRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamRepository.java
@@ -2,9 +2,29 @@ package com.moyorak.api.team.repository;
 
 import com.moyorak.api.company.domain.Company;
 import com.moyorak.api.team.domain.Team;
+import jakarta.persistence.QueryHint;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends CrudRepository<Team, Long> {
 
     boolean existsByCompanyAndName(Company company, String name);
+
+    @Query(
+            """
+            SELECT t
+            FROM Team t
+            JOIN FETCH t.company
+            WHERE t.company.id = :teamId
+            and t.use = true
+            and t.company.use = true
+        """)
+    @QueryHints(
+            @QueryHint(
+                    name = "org.hibernate.comment",
+                    value = "TeamRepository.findByTeamId : 팀 고유 ID로 Team 정보를 조회합니다."))
+    Optional<Team> findByTeamId(@Param("teamId") Long teamId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/moyorak/api/team/repository/TeamUserRepository.java
@@ -30,6 +30,18 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     @Query(
             """
+                SELECT tu
+                FROM TeamUser tu
+                JOIN FETCH tu.team t
+                JOIN FETCH t.company
+                WHERE tu.userId = :userId
+                and tu.use = :use
+        """)
+    Optional<TeamUser> findWithTeamAndCompany(
+            @Param("userId") Long userId, @Param("use") boolean use);
+
+    @Query(
+            """
                     SELECT tu
                     FROM TeamUser tu
                     JOIN Team t ON tu.team.id = t.id

--- a/src/main/java/com/moyorak/api/team/service/TeamUserService.java
+++ b/src/main/java/com/moyorak/api/team/service/TeamUserService.java
@@ -1,5 +1,6 @@
 package com.moyorak.api.team.service;
 
+import com.moyorak.api.auth.dto.UserOrganisationResponse;
 import com.moyorak.api.team.domain.Team;
 import com.moyorak.api.team.domain.TeamRole;
 import com.moyorak.api.team.domain.TeamUser;
@@ -124,5 +125,21 @@ public class TeamUserService {
     @Transactional(readOnly = true)
     public boolean isTeamAdmin(final Long userId) {
         return teamUserRepository.isTeamAdmin(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public UserOrganisationResponse getTeamId(final Long userId) {
+        final Long teamId =
+                teamUserRepository
+                        .findWithTeamAndCompany(userId, true)
+                        .orElseThrow(() -> new BusinessException("해당 팀의 팀원이 아닙니다."))
+                        .getTeamId();
+
+        final Team team =
+                teamRepository
+                        .findByTeamId(teamId, userId)
+                        .orElseThrow(() -> new BusinessException("유효하지 않은 팀 ID 입니다."));
+
+        return UserOrganisationResponse.from(team.getCompanyId(), teamId);
     }
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 로그인 정보로 회원의 회사, 팀 ID를 조회하는 API 추가하였습니다.

---

## 📝 코멘트
- 로그인 정보로 회원의 회사, 팀 ID를 조회하는 API 추가