### PR TITLE
fix: #310 팀 ID 비교 검증 로직 변경

### DIFF
--- a/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
+++ b/src/main/java/com/moyorak/api/party/service/PartyAttendeeService.java
@@ -70,7 +70,7 @@ public class PartyAttendeeService {
     }
 
     private void validateSameTeam(final TeamUser teamUser, final Party party) {
-        if (!Objects.equals(teamUser.getTeam().getId(), party.getId())) {
+        if (!Objects.equals(teamUser.getTeam().getId(), party.getTeamId())) {
             throw new NotTeamUserException();
         }
     }


### PR DESCRIPTION
## 📌 주요 변경 사항
- 팀 ID 와 파티의 팀 ID 비교 로직 변경

---

## 📝 코멘트
파티와 사용자가 같은 팀에 속해 있는지 검증합니다.
