### PR TITLE
chore: #325 회원 프로필 이미지 varchar(256) 에서 varchar(512)로 변경

### DIFF
--- a/src/main/java/com/moyorak/api/auth/domain/User.java
+++ b/src/main/java/com/moyorak/api/auth/domain/User.java
@@ -52,7 +52,7 @@ public class User extends AuditInformation {
     private LocalDate birthday;
 
     @Comment("프로필 이미지 URL")
-    @Column(name = "profile_image", columnDefinition = "varchar(256)")
+    @Column(name = "profile_image", columnDefinition = "varchar(512)")
     private String profileImage;
 
     @NotNull


### PR DESCRIPTION
## 📌 주요 변경 사항
- 회원 프로필 이미지 uri 긴게 들어오면 저장이 안되어 512로 자릿수 변경

---

## 📝 코멘트
- 회원 프로필 이미지 varchar(256) 에서 varchar(512)로 변경